### PR TITLE
[Feature] #15 : 채팅 메시지 전송 시간 표시 및 채팅방 중복 생성 방지 기능 구현

### DIFF
--- a/src/main/java/com/kbulkup/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/kbulkup/auth/service/AuthServiceImpl.java
@@ -38,7 +38,7 @@ public class AuthServiceImpl implements AuthService {
         }
 
         // 요청된 역할만 포함하여 JWT 토큰 생성
-        String accesstoken = jwtTokenProvider.createToken(user.getEmail(), Collections.singletonList(requestedRole));
+        String accesstoken = jwtTokenProvider.createToken(user.getEmail(), user.getUserId(), Collections.singletonList(requestedRole));
 
         return LoginResponseDTO.toDTO(user, accesstoken, role);
     }

--- a/src/main/java/com/kbulkup/chat/controller/ChatController.java
+++ b/src/main/java/com/kbulkup/chat/controller/ChatController.java
@@ -1,0 +1,22 @@
+package com.kbulkup.chat.controller;
+
+import com.kbulkup.chat.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat/send-message")
+    public void sendMessage(ChatMessage chatMessage) {
+        chatMessage.setSendAt(LocalDateTime.now());
+        messagingTemplate.convertAndSend("/topic/room/" + chatMessage.getRoomId(), chatMessage);
+    }
+}

--- a/src/main/java/com/kbulkup/chat/domain/ChatMessage.java
+++ b/src/main/java/com/kbulkup/chat/domain/ChatMessage.java
@@ -1,0 +1,19 @@
+package com.kbulkup.chat.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ChatMessage {
+
+    private String roomId;
+    private String senderId;
+    private String message;
+
+    @Setter
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime sendAt;
+}

--- a/src/main/java/com/kbulkup/common/config/SecurityConfig.java
+++ b/src/main/java/com/kbulkup/common/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.kbulkup.common.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -35,8 +36,10 @@ public class SecurityConfig {
                 .cors() // CORS 설정 추가
                 .and()
                 .authorizeRequests()
+                .antMatchers("/ws/**").permitAll()
+                .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .antMatchers("/api/common/auth/login", "/api/common/auth/signup").permitAll()
-                .antMatchers(org.springframework.http.HttpMethod.OPTIONS, "/api/common/auth/**").permitAll()
+                .antMatchers(HttpMethod.OPTIONS, "/api/common/auth/**").permitAll()
                 .antMatchers("/api/trainer/**").hasRole("TRAINER")
                 .antMatchers("/api/trainee/**").hasRole("TRAINEE")
                 .antMatchers("/api/common/**").hasAnyRole("TRAINER", "TRAINEE") // common 경로는 두 역할 모두 접근 가능
@@ -55,7 +58,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173")); // 허용할 Origin 설정
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173", "http://localhost:5500")); // 허용할 Origin 설정
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP Method 설정
         configuration.setAllowedHeaders(Arrays.asList("*")); // 모든 Header 허용
         configuration.setAllowCredentials(true); // 자격 증명 허용

--- a/src/main/java/com/kbulkup/common/config/WebConfig.java
+++ b/src/main/java/com/kbulkup/common/config/WebConfig.java
@@ -1,8 +1,5 @@
 package com.kbulkup.common.config;
 
-import com.kbulkup.common.config.RootConfig;
-import com.kbulkup.common.config.ServletConfig;
-import com.kbulkup.common.config.SecurityConfig;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
@@ -23,7 +20,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
 
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class[]{RootConfig.class, SecurityConfig.class};
+        return new Class[]{RootConfig.class, SecurityConfig.class, WebSocketConfig.class};
     }
 
     @Override

--- a/src/main/java/com/kbulkup/common/config/WebSocketConfig.java
+++ b/src/main/java/com/kbulkup/common/config/WebSocketConfig.java
@@ -13,8 +13,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("*")
-                .withSockJS();
+                .setAllowedOriginPatterns("*");
     }
 
     @Override

--- a/src/main/java/com/kbulkup/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/kbulkup/common/security/JwtTokenProvider.java
@@ -33,8 +33,9 @@ public class JwtTokenProvider {
     }
 
     // 최종 인증 JWT 생성
-    public String createToken(String userPk, List<String> roles) {
+    public String createToken(String userPk, Long userId, List<String> roles) {
         Claims claims = Jwts.claims().setSubject(userPk);
+        claims.put("userId", userId);
         claims.put("roles", roles);
         Date now = new Date();
         return Jwts.builder()
@@ -72,5 +73,24 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKeyBytes)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("userId", Long.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getRoles(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKeyBytes)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return (List<String>) claims.get("roles");
     }
 }

--- a/src/main/java/com/kbulkup/counseling/controller/CounselingController.java
+++ b/src/main/java/com/kbulkup/counseling/controller/CounselingController.java
@@ -2,27 +2,30 @@ package com.kbulkup.counseling.controller;
 
 import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.counseling.dto.request.CounselingCreateRequestDTO;
+import com.kbulkup.counseling.dto.response.CounselingCreateResponseDTO;
 import com.kbulkup.counseling.dto.response.TrainerCounselingListResponseDTO;
 import com.kbulkup.counseling.service.CounselingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/trainer/counselings")
+@RequestMapping("/api/common/counselings")
 public class CounselingController {
 
     private final CounselingService counselingService;
 
-    @GetMapping("/{trainerId}")
-    public CustomResponse<List<TrainerCounselingListResponseDTO>> readCounselings(@PathVariable Long trainerId) {
+    @GetMapping("/{userId}")
+    public CustomResponse<List<TrainerCounselingListResponseDTO>> readCounselings(@PathVariable Long userId) {
         //trainerId -> Authentication authentication 으로 변경 예정
-        return CustomResponse.success(ResponseCode.SUCCESS, counselingService.getCounselingsByTrainer(trainerId));
+        return CustomResponse.success(ResponseCode.SUCCESS, counselingService.getCounselingsByTrainer(userId));
+    }
+
+    @PostMapping("")
+    public CustomResponse<CounselingCreateResponseDTO> createCounselings(@RequestBody CounselingCreateRequestDTO dto) {
+        return CustomResponse.success(ResponseCode.SUCCESS, counselingService.createOrGetCounselingsRoom(dto.getTrainerId(), dto.getTraineeId(), dto.getTrainingId()));
     }
 }

--- a/src/main/java/com/kbulkup/counseling/domain/Counseling.java
+++ b/src/main/java/com/kbulkup/counseling/domain/Counseling.java
@@ -24,4 +24,16 @@ public class Counseling {
     private LocalDateTime latestAt;
     private LocalDateTime startAt;
     private LocalDateTime expiresAt;
+
+    public static Counseling createCounseling(Long traineeId, Long trainerId, Long trainingId, String roomId) {
+        return Counseling.builder()
+                .userId(traineeId)
+                .trainerId(trainerId)
+                .trainingId(trainingId)
+                .roomId(roomId)
+                .status("1일 남음")
+                .startAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusDays(1))
+                .build();
+    }
 }

--- a/src/main/java/com/kbulkup/counseling/dto/request/CounselingCreateRequestDTO.java
+++ b/src/main/java/com/kbulkup/counseling/dto/request/CounselingCreateRequestDTO.java
@@ -1,0 +1,11 @@
+package com.kbulkup.counseling.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CounselingCreateRequestDTO {
+
+    private Long traineeId;
+    private Long trainerId;
+    private Long trainingId;
+}

--- a/src/main/java/com/kbulkup/counseling/dto/response/CounselingCreateResponseDTO.java
+++ b/src/main/java/com/kbulkup/counseling/dto/response/CounselingCreateResponseDTO.java
@@ -1,0 +1,24 @@
+package com.kbulkup.counseling.dto.response;
+
+import com.kbulkup.counseling.domain.Counseling;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CounselingCreateResponseDTO {
+
+    private String roomId;
+    private boolean isNew;
+
+    public static CounselingCreateResponseDTO toDTO(String roomId, boolean isNew) {
+        return CounselingCreateResponseDTO.builder()
+                .roomId(roomId)
+                .isNew(isNew)
+                .build();
+    }
+}

--- a/src/main/java/com/kbulkup/counseling/mapper/CounselingMapper.java
+++ b/src/main/java/com/kbulkup/counseling/mapper/CounselingMapper.java
@@ -1,7 +1,9 @@
 package com.kbulkup.counseling.mapper;
 
+import com.kbulkup.counseling.domain.Counseling;
 import com.kbulkup.counseling.dto.response.TrainerCounselingListResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -9,4 +11,8 @@ import java.util.List;
 public interface CounselingMapper {
 
     List<TrainerCounselingListResponseDTO> findByTrainerId(Long trainerId);
+
+    Counseling findByTraineeAndTrainer(@Param("traineeId") Long traineeId, @Param("trainerId") Long trainerId);
+
+    void insertCounselings(Counseling counseling);
 }

--- a/src/main/java/com/kbulkup/counseling/service/CounselingService.java
+++ b/src/main/java/com/kbulkup/counseling/service/CounselingService.java
@@ -1,5 +1,6 @@
 package com.kbulkup.counseling.service;
 
+import com.kbulkup.counseling.dto.response.CounselingCreateResponseDTO;
 import com.kbulkup.counseling.dto.response.TrainerCounselingListResponseDTO;
 
 import java.util.List;
@@ -7,4 +8,6 @@ import java.util.List;
 public interface CounselingService {
 
     List<TrainerCounselingListResponseDTO> getCounselingsByTrainer(Long trainerId);
+
+    CounselingCreateResponseDTO createOrGetCounselingsRoom(Long trainerId, Long traineeId, Long trainingId);
 }

--- a/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
+++ b/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
@@ -6,6 +6,7 @@ import com.kbulkup.counseling.dto.response.TrainerCounselingListResponseDTO;
 import com.kbulkup.counseling.mapper.CounselingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +23,7 @@ public class CounselingServiceImpl implements CounselingService {
     }
 
     @Override
+    @Transactional
     public CounselingCreateResponseDTO createOrGetCounselingsRoom(Long trainerId, Long traineeId, Long trainingId) {
         //trainer, trainee, training 존재 여부 처리 추가 예정
 

--- a/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
+++ b/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
@@ -1,11 +1,14 @@
 package com.kbulkup.counseling.service;
 
+import com.kbulkup.counseling.domain.Counseling;
+import com.kbulkup.counseling.dto.response.CounselingCreateResponseDTO;
 import com.kbulkup.counseling.dto.response.TrainerCounselingListResponseDTO;
 import com.kbulkup.counseling.mapper.CounselingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,5 +19,23 @@ public class CounselingServiceImpl implements CounselingService {
     @Override
     public List<TrainerCounselingListResponseDTO> getCounselingsByTrainer(Long trainerId) {
         return counselingMapper.findByTrainerId(trainerId);
+    }
+
+    @Override
+    public CounselingCreateResponseDTO createOrGetCounselingsRoom(Long trainerId, Long traineeId, Long trainingId) {
+        //trainer, trainee, training 존재 여부 처리 추가 예정
+
+        Counseling existing = counselingMapper.findByTraineeAndTrainer(traineeId, trainerId);
+
+        if (existing != null) {
+            return CounselingCreateResponseDTO.toDTO(existing.getRoomId(), false);
+        }
+
+        String roomId = "room-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
+        Counseling counseling = Counseling.createCounseling(traineeId, trainerId, trainingId, roomId);
+        counselingMapper.insertCounselings(counseling);
+
+        return CounselingCreateResponseDTO.toDTO(roomId, true);
     }
 }

--- a/src/main/java/com/kbulkup/user/controller/UserController.java
+++ b/src/main/java/com/kbulkup/user/controller/UserController.java
@@ -1,4 +1,28 @@
 package com.kbulkup.user.controller;
 
+import com.kbulkup.common.response.CustomResponse;
+import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.common.security.JwtTokenProvider;
+import com.kbulkup.user.dto.response.UserResponseDTO;
+import com.kbulkup.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/common/users")
 public class UserController {
+
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/me")
+    public CustomResponse<UserResponseDTO> getMyInfo(HttpServletRequest request) {
+        String token = jwtTokenProvider.resolveToken(request);
+        return CustomResponse.success(ResponseCode.SUCCESS, userService.getUserFromToken(token));
+    }
 }

--- a/src/main/java/com/kbulkup/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/kbulkup/user/dto/response/UserResponseDTO.java
@@ -1,4 +1,22 @@
 package com.kbulkup.user.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
 public class UserResponseDTO {
+
+    private Long userId;
+    private List<String> roles;
+
+    public static UserResponseDTO toDTO(Long userId, List<String> roles) {
+        return UserResponseDTO
+                .builder()
+                .userId(userId)
+                .roles(roles)
+                .build();
+    }
 }

--- a/src/main/java/com/kbulkup/user/service/UserService.java
+++ b/src/main/java/com/kbulkup/user/service/UserService.java
@@ -1,4 +1,8 @@
 package com.kbulkup.user.service;
 
+import com.kbulkup.user.dto.response.UserResponseDTO;
+
 public interface UserService {
+
+    UserResponseDTO getUserFromToken(String token);
 }

--- a/src/main/java/com/kbulkup/user/service/UserServiceImpl.java
+++ b/src/main/java/com/kbulkup/user/service/UserServiceImpl.java
@@ -1,4 +1,22 @@
 package com.kbulkup.user.service;
 
+import com.kbulkup.common.security.JwtTokenProvider;
+import com.kbulkup.user.dto.response.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public UserResponseDTO getUserFromToken(String token) {
+        Long userId = jwtTokenProvider.getUserId(token);
+        List<String> roles = jwtTokenProvider.getRoles(token);
+
+        return UserResponseDTO.toDTO(userId, roles);
+    }
 }

--- a/src/main/resources/mappers/counseling/CounselingMapper.xml
+++ b/src/main/resources/mappers/counseling/CounselingMapper.xml
@@ -22,4 +22,36 @@
             WHERE c.trainer_id = #{trainerId}
             ORDER BY c.latest_at DESC
     </select>
+
+    <select id="findByTraineeAndTrainer" resultType="com.kbulkup.counseling.domain.Counseling">
+        SELECT *
+        FROM counselings
+        WHERE user_id = #{traineeId}
+          AND trainer_id = #{trainerId}
+        LIMIT 1
+    </select>
+
+    <insert id="insertCounselings" parameterType="com.kbulkup.counseling.domain.Counseling">
+        INSERT INTO counselings (
+            user_id,
+            trainer_id,
+            training_id,
+            room_id,
+            status,
+            latest_message,
+            latest_at,
+            start_at,
+            expires_at
+        ) VALUES (
+            #{userId},
+            #{trainerId},
+            #{trainingId},
+            #{roomId},
+            #{status},
+            #{latestMessage},
+            #{latestAt},
+            #{startAt},
+            #{expiresAt}
+        )
+    </insert>
 </mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #15

## ✨️ 작업 내용
- [ ] `ChatMessage` 도메인에 sendAt 필드 추가 및 @JsonFormat 적용
- [ ] `ChatController.sendMessage()` 내에서 메시지 전송 시 sendAt을 LocalDateTime.now()로 설정
- [ ] `/api/common/counselings` POST API 추가 (트레이너-수강생-강의 기준 상담방 생성 요청 처리)
- [ ] 기존 상담방 존재 시 해당 roomId 반환, 없을 경우 UUID 기반으로 새로운 상담방 생성 및 저장
- [ ] `CounselingMapper`에 findByTraineeAndTrainer, insertCounselings 메서드 추가 및 XML 쿼리 작성

## 💙 코멘트 (선택)
- 기존 상담방이 있는 경우 기존 roomId 응답 확인
- 새로운 조합일 경우 DB에 상담방 생성됨 확인
- 채팅 메시지 수신 시 sendAt 필드가 정상적으로 포함되어 수신됨

## 📸 구현 결과 (선택)
<img width="940" height="298" alt="image" src="https://github.com/user-attachments/assets/af14c8f3-8f33-486b-a05f-1e09e965cefa" />
<img width="940" height="291" alt="image" src="https://github.com/user-attachments/assets/6f3a3e07-412b-4b83-93a5-080e38289fce" />
