### PR TITLE
[Feature] #41 : 자산 포트폴리오 조회 api

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -41,7 +41,7 @@ CREATE TABLE `user_roles`
 CREATE TABLE `trainer_profiles`
 (
     `trainer_id`           BIGINT    NOT NULL AUTO_INCREMENT,
-    `career`               TEXT      DEFAULT NULL,
+    `career`               TEXT           DEFAULT NULL,
     `total_average_rating` FLOAT     NULL DEFAULT 0,
     `total_trainee_count`  INT       NULL DEFAULT 0,
     `created_at`           TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
@@ -166,15 +166,45 @@ CREATE TABLE `qnas`
 );
 
 -- portfolios
-CREATE TABLE `portfolios`
+CREATE TABLE portfolios
 (
-    `portfolio_id`       BIGINT    NOT NULL AUTO_INCREMENT,
-    `user_id`            BIGINT    NOT NULL,
-    `total_income`       BIGINT    NOT NULL DEFAULT 0,
-    `total_expense`      BIGINT    NOT NULL DEFAULT 0,
-    `avg_daily_spending` FLOAT     NOT NULL DEFAULT 0.0,
-    `created_at`         TIMESTAMP NULL     DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (`portfolio_id`)
+    user_id BIGINT PRIMARY KEY,
+    FOREIGN KEY (user_id) REFERENCES users (user_id)
+);
+
+-- transactions
+CREATE TABLE transactions
+(
+    transaction_id         BIGINT PRIMARY KEY,
+    user_id                BIGINT            NOT NULL,
+    transaction_type       ENUM ('입금', '출금') NOT NULL,
+    amount                 BIGINT            NOT NULL,
+    `transaction_category` ENUM (
+        '식비', '교통비', '주거/공과금', '생필품',
+        '의료/건강', '패션/미용', '문화생활/여가', '기타',
+        '월급', '부수입'
+        )                                    NULL,
+    tran_date              DATETIME          NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
+);
+
+-- snapshots
+CREATE TABLE snapshots
+(
+    snapshot_id   BIGINT PRIMARY KEY,
+    user_id       BIGINT NOT NULL,
+    balance       BIGINT NOT NULL,
+    snapshot_date DATE   NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
+);
+
+-- compositions
+CREATE TABLE compositions
+(
+    composition_id    BIGINT PRIMARY KEY,
+    user_id           BIGINT NOT NULL,
+    asset_composition JSON   NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
 );
 
 -- counselings
@@ -262,9 +292,6 @@ ALTER TABLE `routine_results`
     ADD CONSTRAINT `FK_routine_results_enrollments` FOREIGN KEY (`enrollment_id`) REFERENCES `enrollments` (`enrollment_id`) ON DELETE CASCADE ON UPDATE CASCADE,
     ADD CONSTRAINT `FK_routine_results_routines` FOREIGN KEY (`routine_id`) REFERENCES `routines` (`routine_id`) ON DELETE CASCADE ON UPDATE CASCADE;
 
-ALTER TABLE `portfolios`
-    ADD CONSTRAINT `FK_portfolios_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE;
-
 ALTER TABLE `qnas`
     ADD CONSTRAINT `FK_qnas_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`user_id`) ON DELETE CASCADE ON UPDATE CASCADE,
     ADD CONSTRAINT `FK_qnas_trainings` FOREIGN KEY (`training_id`) REFERENCES `trainings` (`training_id`) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -276,6 +303,29 @@ ALTER TABLE `trainer_certificates`
 ALTER TABLE `admin_approval_logs`
     ADD CONSTRAINT `FK_admin_approval_logs_trainings` FOREIGN KEY (`training_id`) REFERENCES `trainings` (`training_id`) ON DELETE CASCADE ON UPDATE CASCADE,
     ADD CONSTRAINT `FK_admin_approval_logs_trainer_profiles` FOREIGN KEY (`trainer_id`) REFERENCES `trainer_profiles` (`trainer_id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE portfolios
+    ADD CONSTRAINT fk_portfolios_user
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+            ON DELETE CASCADE;
+
+-- 자산 구성
+ALTER TABLE compositions
+    ADD CONSTRAINT fk_compositions_portfolio
+        FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
+            ON DELETE CASCADE;
+
+-- 자산 추이
+ALTER TABLE snapshots
+    ADD CONSTRAINT fk_snapshots_portfolio
+        FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
+            ON DELETE CASCADE;
+
+-- 거래 내역
+ALTER TABLE transactions
+    ADD CONSTRAINT fk_transactions_portfolio
+        FOREIGN KEY (user_id) REFERENCES portfolios (user_id)
+            ON DELETE CASCADE;
 
 -- admin_approval_logs 의 admin_id 외래키 생략 주석 유지
 -- ALTER TABLE admin_approval_logs ADD CONSTRAINT FK_admin_approval_logs_admins FOREIGN KEY (admin_id)

--- a/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
+++ b/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/trainee")
+@RequestMapping("/api/trainee/assets")
 public class TraineeAssetController {
 
     private final TraineeAssetService traineeAssetService;

--- a/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
+++ b/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
@@ -1,0 +1,29 @@
+package com.kbulkup.asset.controller;
+
+import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
+import com.kbulkup.asset.service.TraineeAssetService;
+import com.kbulkup.common.response.CustomResponse;
+import com.kbulkup.common.response.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trainee")
+public class TraineeAssetController {
+
+    private final TraineeAssetService traineeAssetService;
+
+    @GetMapping("/{traineeId}")
+    public CustomResponse<TraineeAssetDetailResponseDTO> getTraineeAsset(@PathVariable Long traineeId) {
+        TraineeAssetDetailResponseDTO dto = traineeAssetService.getTraineeAsset(traineeId);
+
+        if (dto.getTransactions().isEmpty() && dto.getSnapshots().isEmpty() && dto.getComposition() == null) {
+            return CustomResponse.success(ResponseCode.SUCCESS);
+        }
+        return CustomResponse.success(ResponseCode.SUCCESS, dto);
+    }
+}

--- a/src/main/java/com/kbulkup/asset/domain/Composition.java
+++ b/src/main/java/com/kbulkup/asset/domain/Composition.java
@@ -1,0 +1,20 @@
+package com.kbulkup.asset.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Composition {
+    private Long compositionId;
+    private Long userId;
+    private Map<String, Double> assetComposition;
+}

--- a/src/main/java/com/kbulkup/asset/domain/Snapshot.java
+++ b/src/main/java/com/kbulkup/asset/domain/Snapshot.java
@@ -1,0 +1,19 @@
+package com.kbulkup.asset.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Snapshot {
+    private Long snapshotId;
+    private Long userId;
+    private Long balance;
+    private LocalDate snapshotDate;
+}

--- a/src/main/java/com/kbulkup/asset/domain/Transaction.java
+++ b/src/main/java/com/kbulkup/asset/domain/Transaction.java
@@ -1,0 +1,21 @@
+package com.kbulkup.asset.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Transaction {
+    private Long transactionId;
+    private Long userId;
+    private String transactionType;
+    private Long amount;
+    private String transactionCategory;
+    private LocalDateTime tranDate;
+}

--- a/src/main/java/com/kbulkup/asset/dto/response/TraineeAssetDetailResponseDTO.java
+++ b/src/main/java/com/kbulkup/asset/dto/response/TraineeAssetDetailResponseDTO.java
@@ -1,0 +1,29 @@
+package com.kbulkup.asset.dto.response;
+
+import com.kbulkup.asset.domain.Composition;
+import com.kbulkup.asset.domain.Snapshot;
+import com.kbulkup.asset.domain.Transaction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraineeAssetDetailResponseDTO {
+    private List<Transaction> transactions;
+    private List<Snapshot> snapshots;
+    private Composition composition;
+
+    public static TraineeAssetDetailResponseDTO toDTO(List<Transaction> transactions, List<Snapshot> snapshots, Composition composition) {
+        return TraineeAssetDetailResponseDTO.builder()
+                .transactions(transactions)
+                .snapshots(snapshots)
+                .composition(composition)
+                .build();
+    }
+}

--- a/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
+++ b/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
@@ -1,0 +1,20 @@
+package com.kbulkup.asset.mapper;
+
+import com.kbulkup.asset.domain.Composition;
+import com.kbulkup.asset.domain.Snapshot;
+import com.kbulkup.asset.domain.Transaction;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface TraineeAssetMapper {
+
+    List<Transaction> getTransactionsByTraineeId(@Param("traineeId") Long TraineeId);
+
+    List<Snapshot> getSnapshotsByTraineeId(@Param("traineeId") Long TraineeId);
+
+    Composition getCompositionsByTraineeId(@Param("traineeId") Long TraineeId);
+
+}

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
@@ -1,0 +1,8 @@
+package com.kbulkup.asset.service;
+
+import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
+
+public interface TraineeAssetService {
+
+    TraineeAssetDetailResponseDTO getTraineeAsset(Long id);
+}

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
@@ -1,0 +1,27 @@
+package com.kbulkup.asset.service;
+
+import com.kbulkup.asset.domain.Composition;
+import com.kbulkup.asset.domain.Snapshot;
+import com.kbulkup.asset.domain.Transaction;
+import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
+import com.kbulkup.asset.mapper.TraineeAssetMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TraineeAssetServiceImpl implements TraineeAssetService {
+
+    private final TraineeAssetMapper traineeAssetMapper;
+
+    @Override
+    public TraineeAssetDetailResponseDTO getTraineeAsset(Long id) {
+        List<Transaction> transactions = traineeAssetMapper.getTransactionsByTraineeId(id);
+        List<Snapshot> snapshots = traineeAssetMapper.getSnapshotsByTraineeId(id);
+        Composition compositionsByTraineeId = traineeAssetMapper.getCompositionsByTraineeId(id);
+
+        return TraineeAssetDetailResponseDTO.toDTO(transactions, snapshots, compositionsByTraineeId);
+    }
+}

--- a/src/main/java/com/kbulkup/asset/typehandler/JsonToMapTypeHandler.java
+++ b/src/main/java/com/kbulkup/asset/typehandler/JsonToMapTypeHandler.java
@@ -1,0 +1,56 @@
+package com.kbulkup.asset.typehandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+import java.math.BigDecimal;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonToMapTypeHandler extends BaseTypeHandler<Map<String, BigDecimal>> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Map<String, BigDecimal> parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, toJson(parameter));
+    }
+
+    @Override
+    public Map<String, BigDecimal> getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return toMap(rs.getString(columnName));
+    }
+
+    @Override
+    public Map<String, BigDecimal> getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return toMap(rs.getString(columnIndex));
+    }
+
+    @Override
+    public Map<String, BigDecimal> getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return toMap(cs.getString(columnIndex));
+    }
+
+    private String toJson(Map<String, BigDecimal> map) {
+        try {
+            return objectMapper.writeValueAsString(map);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, BigDecimal> toMap(String json) {
+        try {
+            if (json == null || json.isEmpty()) return new HashMap<>();
+            return objectMapper.readValue(json, objectMapper.getTypeFactory()
+                    .constructMapType(Map.class, String.class, BigDecimal.class));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/mappers/asset/TraineeAssetMapper.xml
+++ b/src/main/resources/mappers/asset/TraineeAssetMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kbulkup.asset.mapper.TraineeAssetMapper">
+
+    <select id="getTransactionsByTraineeId" resultType="com.kbulkup.asset.domain.Transaction">
+        SELECT
+            transaction_id,
+            user_id,
+            transaction_type,
+            amount,
+            transaction_category,
+            tran_date
+        FROM transactions
+        WHERE user_id = #{traineeId}
+        ORDER BY tran_date DESC
+    </select>
+
+    <select id="getSnapshotsByTraineeId" resultType="com.kbulkup.asset.domain.Snapshot">
+        SELECT
+            snapshot_id,
+            user_id,
+            balance,
+            snapshot_date
+        FROM snapshots
+        WHERE user_id = #{traineeId}
+        ORDER BY snapshot_date DESC
+    </select>
+
+    <resultMap id="CompositionResultMap" type="com.kbulkup.asset.domain.Composition">
+        <id property="compositionId" column="composition_id"/>
+        <result property="userId" column="user_id"/>
+        <result property="assetComposition" column="asset_composition" typeHandler="com.kbulkup.asset.typehandler.JsonToMapTypeHandler"/>
+    </resultMap>
+
+    <select id="getCompositionsByTraineeId" resultMap="CompositionResultMap">
+        SELECT
+            composition_id,
+            user_id,
+            asset_composition
+        FROM compositions
+        WHERE user_id = #{traineeId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- [Feature]: 자산 포트폴리오 조회 api  #41 

## ✨️ 작업 내용
- [x] 테이블 구성 변경하기
- [X] DB내 회원 자산 포트폴리오 GET API 구현하기

## 💙 코멘트 (선택)
- 자산 구성 타입은 json으로 인해 typehandler를 사용하였습니다.

## 📸 구현 결과 (선택)
<img width="482" height="389" alt="image" src="https://github.com/user-attachments/assets/da0e80ad-f366-4de3-8b4b-950b70ed628f" />

