### PR TITLE
[Feature] #48: 외부 api와 연동하여 마이데이터 DB 저장

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -227,7 +227,6 @@ CREATE TABLE `user_fintech_auths`
     `user_id`         BIGINT       NOT NULL,
     `fintech_use_num` VARCHAR(100) NULL,
     `bank_code`       VARCHAR(10)  NULL,
-    `account_name`    VARCHAR(50)  NULL,
     `created_at`      TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`user_id`)
 );

--- a/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
+++ b/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
@@ -1,14 +1,12 @@
 package com.kbulkup.asset.controller;
 
+import com.kbulkup.asset.dto.request.TokenRequestDTO;
 import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
 import com.kbulkup.asset.service.TraineeAssetService;
 import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.common.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +23,12 @@ public class TraineeAssetController {
             return CustomResponse.success(ResponseCode.SUCCESS);
         }
         return CustomResponse.success(ResponseCode.SUCCESS, dto);
+    }
+
+    @PostMapping("/account/{traineeId}")
+    public CustomResponse<Void> postTraineeAccount(@RequestBody TokenRequestDTO dto, @PathVariable Long traineeId) {
+        traineeAssetService.createUserPortfolio(dto.getBank(), traineeId);
+
+        return CustomResponse.success(ResponseCode.SUCCESS);
     }
 }

--- a/src/main/java/com/kbulkup/asset/domain/Transaction.java
+++ b/src/main/java/com/kbulkup/asset/domain/Transaction.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -16,6 +16,6 @@ public class Transaction {
     private Long userId;
     private String transactionType;
     private Long amount;
-    private String transactionCategory;
-    private LocalDateTime tranDate;
+    private TransactionCategory transactionCategory;
+    private LocalDate tranDate;
 }

--- a/src/main/java/com/kbulkup/asset/domain/TransactionCategory.java
+++ b/src/main/java/com/kbulkup/asset/domain/TransactionCategory.java
@@ -1,0 +1,33 @@
+package com.kbulkup.asset.domain;
+
+public enum TransactionCategory {
+    주거_공과금("주거/공과금"),
+    문화생활_여가("문화생활/여가"),
+    패션_미용("패션/미용"),
+    기타("기타"),
+    월급("월급"),
+    부수입("부수입"),
+    식비("식비"),
+    교통비("교통비"),
+    생필품("생필품"),
+    의료_건강("의료/건강");
+
+    private final String dbValue;
+
+    TransactionCategory(String dbValue) {
+        this.dbValue = dbValue;
+    }
+
+    public String toDbValue() {
+        return dbValue;
+    }
+
+    public static TransactionCategory fromDbValue(String dbValue) {
+        for (TransactionCategory tc : values()) {
+            if (tc.dbValue.equals(dbValue)) {
+                return tc;
+            }
+        }
+        throw new IllegalArgumentException("Unknown category: " + dbValue);
+    }
+}

--- a/src/main/java/com/kbulkup/asset/dto/request/TokenRequestDTO.java
+++ b/src/main/java/com/kbulkup/asset/dto/request/TokenRequestDTO.java
@@ -1,0 +1,21 @@
+package com.kbulkup.asset.dto.request;
+
+import com.mysql.cj.jdbc.StatementImpl;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenRequestDTO {
+    private String bank;
+
+    public static TokenRequestDTO create(String bank) {
+        return TokenRequestDTO.builder()
+                .bank(bank)
+                .build();
+    }
+}

--- a/src/main/java/com/kbulkup/asset/dto/response/ExternalAssetResponseDTO.java
+++ b/src/main/java/com/kbulkup/asset/dto/response/ExternalAssetResponseDTO.java
@@ -1,0 +1,18 @@
+package com.kbulkup.asset.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExternalAssetResponseDTO {
+    private String fintechUseNum;
+
+    @JsonProperty("portfolio")
+    private TraineeAssetDetailResponseDTO traineeAssetDetailResponseDTO;
+}

--- a/src/main/java/com/kbulkup/asset/dto/response/ExternalTokenResponseDTO.java
+++ b/src/main/java/com/kbulkup/asset/dto/response/ExternalTokenResponseDTO.java
@@ -1,0 +1,15 @@
+package com.kbulkup.asset.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExternalTokenResponseDTO {
+    private String accessToken;
+    private String fintechUseNum;
+}

--- a/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
+++ b/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
@@ -17,6 +17,8 @@ public interface TraineeAssetMapper {
 
     Composition getCompositionsByTraineeId(@Param("traineeId") Long TraineeId);
 
+    void insertPortfolio(@Param("traineeId") Long id);
+
     void insertTransactions(@Param("traineeId") Long TraineeId, @Param("transactions") List<Transaction> transactions);
 
     void insertSnapshots(@Param("traineeId") Long TraineeId, @Param("snapshots") List<Snapshot> snapshots);

--- a/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
+++ b/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
@@ -17,4 +17,9 @@ public interface TraineeAssetMapper {
 
     Composition getCompositionsByTraineeId(@Param("traineeId") Long TraineeId);
 
+    void insertTransactions(@Param("traineeId") Long TraineeId, @Param("transactions") List<Transaction> transactions);
+
+    void insertSnapshots(@Param("traineeId") Long TraineeId, @Param("snapshots") List<Snapshot> snapshots);
+
+    void insertComposition(@Param("traineeId") Long TraineeId, @Param("composition") Composition composition);
 }

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
@@ -5,4 +5,7 @@ import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
 public interface TraineeAssetService {
 
     TraineeAssetDetailResponseDTO getTraineeAsset(Long id);
+
+    void createUserPortfolio(String bank, Long id);
+
 }

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
@@ -4,7 +4,8 @@ import com.kbulkup.asset.domain.Composition;
 import com.kbulkup.asset.domain.Snapshot;
 import com.kbulkup.asset.domain.Transaction;
 import com.kbulkup.asset.dto.request.TokenRequestDTO;
-import com.kbulkup.asset.dto.response.TokenResponseDTO;
+import com.kbulkup.asset.dto.response.ExternalAssetResponseDTO;
+import com.kbulkup.asset.dto.response.ExternalTokenResponseDTO;
 import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
 import com.kbulkup.asset.mapper.TraineeAssetMapper;
 import lombok.RequiredArgsConstructor;
@@ -32,42 +33,44 @@ public class TraineeAssetServiceImpl implements TraineeAssetService {
     @Override
     @Transactional
     public void createUserPortfolio(String bank, Long id) {
-        TokenResponseDTO dto = getAccessToken(bank, id);
-        insertTraineeAsset(id, getUserAssetData(dto.getAccessToken()));
+        ExternalTokenResponseDTO externalTokenResponseDTO = getAccessToken(bank, id);
+        ExternalAssetResponseDTO externalAssetResponseDTO = getUserAssetData(externalTokenResponseDTO.getAccessToken());
+        insertTraineeAsset(id, externalAssetResponseDTO.getTraineeAssetDetailResponseDTO());
     }
 
     @Transactional
     public void insertTraineeAsset(Long id, TraineeAssetDetailResponseDTO dto) {
+        traineeAssetMapper.insertPortfolio(id);
         traineeAssetMapper.insertTransactions(id, dto.getTransactions());
         traineeAssetMapper.insertSnapshots(id, dto.getSnapshots());
         traineeAssetMapper.insertComposition(id, dto.getComposition());
     }
 
-    private TokenResponseDTO getAccessToken(String bank, Long id) {
+    private ExternalTokenResponseDTO getAccessToken(String bank, Long id) {
         WebClient webClient = WebClient
                 .builder()
-                .baseUrl("http://localhost:8888")
+                .baseUrl("http://localhost:9080")
                 .build();
         return webClient.post()
                 .uri("/external-api/token")
                 .header("X-User-Id", String.valueOf(id))
                 .bodyValue(TokenRequestDTO.create(bank))
                 .retrieve()
-                .bodyToMono(TokenResponseDTO.class)
+                .bodyToMono(ExternalTokenResponseDTO.class)
                 .block();
     }
 
-    private TraineeAssetDetailResponseDTO getUserAssetData(String token) {
+    private ExternalAssetResponseDTO getUserAssetData(String token) {
         WebClient webClient = WebClient
                 .builder()
-                .baseUrl("http://localhost:8888")
+                .baseUrl("http://localhost:9080")
                 .build();
 
         return webClient.post()
                 .uri("/external-api/user-data")
                 .header("Authorization", "Bearer " + token)
                 .retrieve()
-                .bodyToMono(TraineeAssetDetailResponseDTO.class)
+                .bodyToMono(ExternalAssetResponseDTO.class)
                 .block();
     }
 }

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
@@ -3,10 +3,14 @@ package com.kbulkup.asset.service;
 import com.kbulkup.asset.domain.Composition;
 import com.kbulkup.asset.domain.Snapshot;
 import com.kbulkup.asset.domain.Transaction;
+import com.kbulkup.asset.dto.request.TokenRequestDTO;
+import com.kbulkup.asset.dto.response.TokenResponseDTO;
 import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
 import com.kbulkup.asset.mapper.TraineeAssetMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 
@@ -23,5 +27,47 @@ public class TraineeAssetServiceImpl implements TraineeAssetService {
         Composition compositionsByTraineeId = traineeAssetMapper.getCompositionsByTraineeId(id);
 
         return TraineeAssetDetailResponseDTO.toDTO(transactions, snapshots, compositionsByTraineeId);
+    }
+
+    @Override
+    @Transactional
+    public void createUserPortfolio(String bank, Long id) {
+        TokenResponseDTO dto = getAccessToken(bank, id);
+        insertTraineeAsset(id, getUserAssetData(dto.getAccessToken()));
+    }
+
+    @Transactional
+    public void insertTraineeAsset(Long id, TraineeAssetDetailResponseDTO dto) {
+        traineeAssetMapper.insertTransactions(id, dto.getTransactions());
+        traineeAssetMapper.insertSnapshots(id, dto.getSnapshots());
+        traineeAssetMapper.insertComposition(id, dto.getComposition());
+    }
+
+    private TokenResponseDTO getAccessToken(String bank, Long id) {
+        WebClient webClient = WebClient
+                .builder()
+                .baseUrl("http://localhost:8888")
+                .build();
+        return webClient.post()
+                .uri("/external-api/token")
+                .header("X-User-Id", String.valueOf(id))
+                .bodyValue(TokenRequestDTO.create(bank))
+                .retrieve()
+                .bodyToMono(TokenResponseDTO.class)
+                .block();
+    }
+
+    private TraineeAssetDetailResponseDTO getUserAssetData(String token) {
+        WebClient webClient = WebClient
+                .builder()
+                .baseUrl("http://localhost:8888")
+                .build();
+
+        return webClient.post()
+                .uri("/external-api/user-data")
+                .header("Authorization", "Bearer " + token)
+                .retrieve()
+                .bodyToMono(TraineeAssetDetailResponseDTO.class)
+                .block();
     }
 }

--- a/src/main/java/com/kbulkup/asset/typehandler/TransactionCategoryTypeHandler.java
+++ b/src/main/java/com/kbulkup/asset/typehandler/TransactionCategoryTypeHandler.java
@@ -1,0 +1,38 @@
+package com.kbulkup.asset.typehandler;
+
+import com.kbulkup.asset.domain.TransactionCategory;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedJdbcTypes;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+
+@MappedTypes(TransactionCategory.class)
+@MappedJdbcTypes(JdbcType.VARCHAR)
+public class TransactionCategoryTypeHandler extends BaseTypeHandler<TransactionCategory> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, TransactionCategory category, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, category.toDbValue());  // 💡 핵심
+    }
+
+    @Override
+    public TransactionCategory getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return TransactionCategory.fromDbValue(rs.getString(columnName));
+    }
+
+    @Override
+    public TransactionCategory getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return TransactionCategory.fromDbValue(rs.getString(columnIndex));
+    }
+
+    @Override
+    public TransactionCategory getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return TransactionCategory.fromDbValue(cs.getString(columnIndex));
+    }
+}

--- a/src/main/resources/mappers/asset/TraineeAssetMapper.xml
+++ b/src/main/resources/mappers/asset/TraineeAssetMapper.xml
@@ -5,24 +5,22 @@
 
 <mapper namespace="com.kbulkup.asset.mapper.TraineeAssetMapper">
     <select id="getTransactionsByTraineeId" resultType="com.kbulkup.asset.domain.Transaction">
-        SELECT
-            transaction_id,
-            user_id,
-            transaction_type,
-            amount,
-            transaction_category,
-            tran_date
+        SELECT transaction_id,
+               user_id,
+               transaction_type,
+               amount,
+               transaction_category,
+               tran_date
         FROM transactions
         WHERE user_id = #{traineeId}
         ORDER BY tran_date DESC
     </select>
 
     <select id="getSnapshotsByTraineeId" resultType="com.kbulkup.asset.domain.Snapshot">
-        SELECT
-            snapshot_id,
-            user_id,
-            balance,
-            snapshot_date
+        SELECT snapshot_id,
+               user_id,
+               balance,
+               snapshot_date
         FROM snapshots
         WHERE user_id = #{traineeId}
         ORDER BY snapshot_date DESC
@@ -31,17 +29,22 @@
     <resultMap id="CompositionResultMap" type="com.kbulkup.asset.domain.Composition">
         <id property="compositionId" column="composition_id"/>
         <result property="userId" column="user_id"/>
-        <result property="assetComposition" column="asset_composition" typeHandler="com.kbulkup.asset.typehandler.JsonToMapTypeHandler"/>
+        <result property="assetComposition" column="asset_composition"
+                typeHandler="com.kbulkup.asset.typehandler.JsonToMapTypeHandler"/>
     </resultMap>
 
     <select id="getCompositionsByTraineeId" resultMap="CompositionResultMap">
-        SELECT
-            composition_id,
-            user_id,
-            asset_composition
+        SELECT composition_id,
+               user_id,
+               asset_composition
         FROM compositions
         WHERE user_id = #{traineeId}
     </select>
+
+    <insert id="insertPortfolio">
+        INSERT INTO portfolios (user_id)
+        VALUES (#{traineeId})
+    </insert>
 
     <insert id="insertTransactions">
         INSERT INTO transactions (
@@ -59,7 +62,7 @@
             #{transaction.userId},
             #{transaction.transactionType},
             #{transaction.amount},
-            #{transaction.transactionCategory},
+            #{transaction.transactionCategory, typeHandler=com.kbulkup.asset.typehandler.TransactionCategoryTypeHandler},
             #{transaction.tranDate}
             )
         </foreach>
@@ -84,16 +87,12 @@
     </insert>
 
     <insert id="insertComposition">
-        INSERT INTO composition_pools (
-            composition_id,
-            user_id,
-            asset_composition
-        )
-        VALUES (
-                   #{composition.compositionId},
-                   #{composition.userId},
-                   #{composition.assetComposition, typeHandler=com.kbulkup.asset.typehandler.JsonToMapTypeHandler}
-               )
+        INSERT INTO compositions (composition_id,
+                                       user_id,
+                                       asset_composition)
+        VALUES (#{composition.compositionId},
+                #{composition.userId},
+                #{composition.assetComposition, typeHandler=com.kbulkup.asset.typehandler.JsonToMapTypeHandler})
     </insert>
 
 

--- a/src/main/resources/mappers/asset/TraineeAssetMapper.xml
+++ b/src/main/resources/mappers/asset/TraineeAssetMapper.xml
@@ -4,7 +4,6 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.kbulkup.asset.mapper.TraineeAssetMapper">
-
     <select id="getTransactionsByTraineeId" resultType="com.kbulkup.asset.domain.Transaction">
         SELECT
             transaction_id,
@@ -43,5 +42,59 @@
         FROM compositions
         WHERE user_id = #{traineeId}
     </select>
+
+    <insert id="insertTransactions">
+        INSERT INTO transactions (
+        transaction_id,
+        user_id,
+        transaction_type,
+        amount,
+        transaction_category,
+        tran_date
+        )
+        VALUES
+        <foreach collection="transactions" item="transaction" separator=",">
+            (
+            #{transaction.transactionId},
+            #{transaction.userId},
+            #{transaction.transactionType},
+            #{transaction.amount},
+            #{transaction.transactionCategory},
+            #{transaction.tranDate}
+            )
+        </foreach>
+    </insert>
+
+    <insert id="insertSnapshots">
+        INSERT INTO snapshots (
+        snapshot_id,
+        user_id,
+        balance,
+        snapshot_date
+        )
+        VALUES
+        <foreach collection="snapshots" item="snapshot" separator=",">
+            (
+            #{snapshot.snapshotId},
+            #{snapshot.userId},
+            #{snapshot.balance},
+            #{snapshot.snapshotDate}
+            )
+        </foreach>
+    </insert>
+
+    <insert id="insertComposition">
+        INSERT INTO composition_pools (
+            composition_id,
+            user_id,
+            asset_composition
+        )
+        VALUES (
+                   #{composition.compositionId},
+                   #{composition.userId},
+                   #{composition.assetComposition, typeHandler=com.kbulkup.asset.typehandler.JsonToMapTypeHandler}
+               )
+    </insert>
+
 
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -5,4 +5,7 @@
         <setting name="mapUnderscoreToCamelCase" value="true"/>
         <setting name="logImpl" value="STDOUT_LOGGING"/>
     </settings>
+    <typeHandlers>
+        <typeHandler handler="com.kbulkup.asset.typehandler.JsonToMapTypeHandler"/>
+    </typeHandlers>
 </configuration>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -7,5 +7,6 @@
     </settings>
     <typeHandlers>
         <typeHandler handler="com.kbulkup.asset.typehandler.JsonToMapTypeHandler"/>
+        <typeHandler handler="com.kbulkup.asset.typehandler.TransactionCategoryTypeHandler"/>
     </typeHandlers>
 </configuration>


### PR DESCRIPTION
## 📑 이슈 번호
- #48 

## ✨️ 작업 내용
- [x] user_fintech_auths테이블에서 계좌번호 필드 지우기
- [x] 외부 api 호출하기
- [x] 응답값을 DB에 저장하기

## 💙 코멘트 (선택)
- 테스트 해보실 분들을 위해서

1. 하나의 로컬 환경에서 톰캣 서버 2개를 구동하기 위해서는 사진과 같이 톰캣 파일 2개가 필요합니다. 기존 톰캣 파일을 복사해주세요.
<img width="174" height="52" alt="image" src="https://github.com/user-attachments/assets/af9e61be-4c9d-4de0-b798-21a8f227ac8c" />

2. 복사한 톰캣 파일 내의 conf/server.xml 파일 내용을 vi로 수정해야 합니다. 파일 안의 모든port 값의 앞자리를 9로 변경해주세요.
ex) 8080 ->9080
---
typehandler는 어쩔 수 없이 사용하였습니다. 예를 들어 외부 api 서버 거래 내역의 거래 카테고리가 '주거/공과금' 인 경우, 응답값이 '주거_공과금'으로 반환됩니다. 즉, '/'가 '_'로 인식되는 오류가 있어 handler를 사용하였습니다.

3. 인텔리제이에서 한 프로젝트의 구성 편집으로 들어가 HTTP 포트를 9080으로 변경해주세요.

## 📸 구현 결과 (선택)
<img width="1233" height="228" alt="image" src="https://github.com/user-attachments/assets/bcad81ff-eb8f-4ed0-b9d3-216b8b38da24" />
<img width="496" height="521" alt="image" src="https://github.com/user-attachments/assets/5480db55-f441-4f06-8941-3fc40f0636c0" />
