### PR TITLE
[Feature] #17 : 만료된 상담방 채팅 차단 및 상태 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/kbulkup/chat/controller/ChatController.java
+++ b/src/main/java/com/kbulkup/chat/controller/ChatController.java
@@ -22,6 +22,9 @@ public class ChatController {
         chatMessageDTO.setSendAt(LocalDateTime.now());
         ChatSummaryDTO chatSummary = chatService.saveChatMessage(chatMessageDTO);
 
+        // 만료된 방이면 아무것도 하지 않음
+        if (chatSummary == null) return;
+
         //채팅방에 메시지 실시간 전송
         messagingTemplate.convertAndSend("/topic/room/" + chatMessageDTO.getRoomId(), chatMessageDTO);
 

--- a/src/main/java/com/kbulkup/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/kbulkup/chat/service/ChatServiceImpl.java
@@ -5,11 +5,13 @@ import com.kbulkup.chat.domain.MongoChatMessage;
 import com.kbulkup.chat.dto.ChatSummaryDTO;
 import com.kbulkup.chat.repository.ChatMongoRepository;
 import com.kbulkup.counseling.domain.Counseling;
+import com.kbulkup.counseling.domain.CounselingStatus;
 import com.kbulkup.counseling.mapper.CounselingMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -21,22 +23,29 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public ChatSummaryDTO saveChatMessage(ChatMessageDTO chatMessageDTO) {
+    public ChatSummaryDTO saveChatMessage(ChatMessageDTO dto) {
 
-        Counseling counseling = counselingMapper.findByRoomId(chatMessageDTO.getRoomId());
-        String receiverId = chatMessageDTO.getSenderId().equals(counseling.getUserId().toString())
+        Counseling counseling = counselingMapper.findByRoomId(dto.getRoomId());
+
+        //만료된 채팅방에서 채팅시 CounselingStatus 수정 및 에러 메시지 반환
+        if (counseling.getExpiresAt().isBefore(LocalDateTime.now())) {
+            counselingMapper.updateStatusToExpired(dto.getRoomId(), CounselingStatus.EXPIRED.getName());
+            return null;
+        }
+
+        String receiverId = dto.getSenderId().equals(counseling.getUserId().toString())
                 ? counseling.getTrainerId().toString() : counseling.getUserId().toString();
 
         //mongodb 채팅 내역 저장
-        MongoChatMessage document = MongoChatMessage.create(chatMessageDTO, receiverId);
+        MongoChatMessage document = MongoChatMessage.create(dto, receiverId);
         chatMongoRepository.save(document);
 
         //mysql 마지막 채팅 시간, 마지막 채팅 업데이트
-        counselingMapper.updateLatestMessage(chatMessageDTO.getRoomId(), chatMessageDTO.getMessage(), chatMessageDTO.getSendAt());
+        counselingMapper.updateLatestMessage(dto.getRoomId(), dto.getMessage(), dto.getSendAt());
 
         //채팅방 요약 정보 전송 위함
-        int unreadCount = (int) chatMongoRepository.countUnreadMessages(chatMessageDTO.getRoomId(), receiverId);
-        return ChatSummaryDTO.create(chatMessageDTO, unreadCount, receiverId);
+        int unreadCount = (int) chatMongoRepository.countUnreadMessages(dto.getRoomId(), receiverId);
+        return ChatSummaryDTO.create(dto, unreadCount, receiverId);
     }
 
     @Override

--- a/src/main/java/com/kbulkup/counseling/dto/response/CounselingDetailResponseDTO.java
+++ b/src/main/java/com/kbulkup/counseling/dto/response/CounselingDetailResponseDTO.java
@@ -15,12 +15,14 @@ public class CounselingDetailResponseDTO {
 
     private String userName;
     private String userProfileUrl;
+    private String status;
     private LocalDateTime expiresAt;
 
-    public static CounselingDetailResponseDTO create(String userName, String userProfileUrl, LocalDateTime expiresAt) {
+    public static CounselingDetailResponseDTO create(String userName, String userProfileUrl, String status, LocalDateTime expiresAt) {
         return CounselingDetailResponseDTO.builder()
                 .userName(userName)
                 .userProfileUrl(userProfileUrl)
+                .status(status)
                 .expiresAt(expiresAt)
                 .build();
     }

--- a/src/main/java/com/kbulkup/counseling/mapper/CounselingMapper.java
+++ b/src/main/java/com/kbulkup/counseling/mapper/CounselingMapper.java
@@ -20,4 +20,6 @@ public interface CounselingMapper {
     void insertCounseling(Counseling counseling);
 
     void updateLatestMessage(@Param("roomId") String roomId, @Param("latestMessage") String latestMessage, @Param("latestAt") LocalDateTime latestAt);
+
+    void updateStatusToExpired(@Param("roomId") String roomId, @Param("status") String status);
 }

--- a/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
+++ b/src/main/java/com/kbulkup/counseling/service/CounselingServiceImpl.java
@@ -65,6 +65,6 @@ public class CounselingServiceImpl implements CounselingService {
 
         User user = userMapper.findById(targetId).orElseThrow(() -> new UserException(ResponseCode.USER_NOT_FOUND));
         //상대방 정보 조회
-        return CounselingDetailResponseDTO.create(user.getUsername(), user.getUserProfileUrl(), counseling.getExpiresAt());
+        return CounselingDetailResponseDTO.create(user.getUsername(), user.getUserProfileUrl(), counseling.getStatus(), counseling.getExpiresAt());
     }
 }

--- a/src/main/resources/mappers/counseling/CounselingMapper.xml
+++ b/src/main/resources/mappers/counseling/CounselingMapper.xml
@@ -70,4 +70,10 @@
             latest_at = #{latestAt}
         WHERE room_id = #{roomId}
     </update>
+
+    <update id="updateStatusToExpired">
+        UPDATE counselings
+        SET status = #{status}
+        WHERE room_id = #{roomId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #17

## ✨️ 작업 내용

- [x] 상담방 종료 시 채팅 전송을 서버에서 차단
- [x] Counseling의 expiresAt이 지났을 경우 상태를 '만료'로 업데이트
- [x] 클라이언트로부터 채팅 요청이 오더라도 status가 '만료'면 저장 및 전송하지 않도록 처리

## 💙 코멘트 (선택)

- 종료 채팅방도 읽기 전용으로 남기고, 새 메시지만 차단하는 방식

## 📸 구현 결과 (선택)
