### PR TITLE
[Feature] #61 : 결제 전 트레이닝 상세 정보 조회 API

### DIFF
--- a/src/main/java/com/kbulkup/training/controller/TrainingController.java
+++ b/src/main/java/com/kbulkup/training/controller/TrainingController.java
@@ -2,9 +2,11 @@ package com.kbulkup.training.controller;
 
 import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.training.dto.request.TraineeTrainingDetailRequestDTO;
 import com.kbulkup.training.dto.request.TrainerTrainingCreateRequestDTO;
 import com.kbulkup.training.dto.request.TrainingSearchListRequestDTO;
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
+import com.kbulkup.training.dto.response.TraineeTrainingDetailResponseDTO;
 import com.kbulkup.training.dto.response.TraineeTrainingListResponseDTO;
 import com.kbulkup.training.dto.response.TrainingSearchListResponseDTO;
 import com.kbulkup.training.service.TraineeTrainingService;
@@ -57,6 +59,14 @@ public class TrainingController {
         return CustomResponse.success(
                 ResponseCode.SUCCESS,
                 traineeTrainingService.getAllApprovedTrainings()
+        );
+    }
+    /** [수강생] 트레이닝 상세 조회 (결제 전) */
+    @GetMapping("/trainee/trainings/{trainingId}")
+    public CustomResponse<TraineeTrainingDetailResponseDTO> getTrainingDetail(@PathVariable Long trainingId) {
+        return CustomResponse.success(
+                ResponseCode.SUCCESS,
+                traineeTrainingService.getTrainingDetail(new TraineeTrainingDetailRequestDTO(trainingId))
         );
     }
 

--- a/src/main/java/com/kbulkup/training/dto/request/TraineeTrainingDetailRequestDTO.java
+++ b/src/main/java/com/kbulkup/training/dto/request/TraineeTrainingDetailRequestDTO.java
@@ -1,0 +1,12 @@
+package com.kbulkup.training.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TraineeTrainingDetailRequestDTO {
+    private Long trainingId;
+}

--- a/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingDetailResponseDTO.java
+++ b/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingDetailResponseDTO.java
@@ -1,0 +1,4 @@
+package com.kbulkup.training.dto.response;
+
+public class TraineeTrainingDetailResponseDTO {
+}

--- a/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingDetailResponseDTO.java
+++ b/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingDetailResponseDTO.java
@@ -1,4 +1,42 @@
 package com.kbulkup.training.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class TraineeTrainingDetailResponseDTO {
+
+    private String title;
+    private String description;
+    private int price;
+    private String category;
+    private String level;
+    private float averageRating;
+    private int traineeCount;
+    private String trainerNickname;
+    private String trainerProfileUrl;
+    private String thumbnailUrl;
+
+    public static TraineeTrainingDetailResponseDTO of(String title, String description, int price,
+                                                      String category, String level, float averageRating,
+                                                      int traineeCount, String trainerNickname,
+                                                      String trainerProfileUrl, String thumbnailUrl) {
+        return TraineeTrainingDetailResponseDTO.builder()
+                .title(title)
+                .description(description)
+                .price(price)
+                .category(category)
+                .level(level)
+                .averageRating(averageRating)
+                .traineeCount(traineeCount)
+                .trainerNickname(trainerNickname)
+                .trainerProfileUrl(trainerProfileUrl)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/kbulkup/training/mapper/TraineeTrainingMapper.java
+++ b/src/main/java/com/kbulkup/training/mapper/TraineeTrainingMapper.java
@@ -2,6 +2,7 @@ package com.kbulkup.training.mapper;
 
 import com.kbulkup.routine.dto.RoutineSummaryResponseDTO;
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
+import com.kbulkup.training.dto.response.TraineeTrainingDetailResponseDTO;
 import com.kbulkup.training.dto.response.TraineeTrainingListResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -24,6 +25,8 @@ public interface TraineeTrainingMapper {
     void updateTrainingProgress(@Param("trainingId") Long trainingId,
                                 @Param("userId") Long userId,
                                 @Param("progress") int progress);
-    /** ✅ 승인된 트레이닝 전체 목록 조회 */
+    /** 승인된 트레이닝 전체 목록 조회 */
     List<TraineeTrainingListResponseDTO> findAllApprovedTrainings();
+
+    TraineeTrainingDetailResponseDTO findTrainingDetail(@Param("trainingId") Long trainingId);
 }

--- a/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
@@ -1,6 +1,8 @@
 package com.kbulkup.training.service;
 
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
+import com.kbulkup.training.dto.request.TraineeTrainingDetailRequestDTO;
+import com.kbulkup.training.dto.response.TraineeTrainingDetailResponseDTO;
 import com.kbulkup.training.dto.response.TraineeTrainingListResponseDTO;
 import com.kbulkup.training.mapper.TraineeTrainingMapper;
 import lombok.RequiredArgsConstructor;
@@ -58,5 +60,10 @@ public class TraineeTrainingService {
     public List<TraineeTrainingListResponseDTO> getAllApprovedTrainings() {
         return traineeTrainingMapper.findAllApprovedTrainings();
     }
+    public TraineeTrainingDetailResponseDTO getTrainingDetail(TraineeTrainingDetailRequestDTO request) {
+        return traineeTrainingMapper.findTrainingDetail(request.getTrainingId());
+    }
+
+
 
 }

--- a/src/main/resources/mappers/training/TraineeTrainingMapper.xml
+++ b/src/main/resources/mappers/training/TraineeTrainingMapper.xml
@@ -64,5 +64,24 @@
         ORDER BY t.created_at DESC
     </select>
 
+    <select id="findTrainingDetail" parameterType="long"
+            resultType="com.kbulkup.training.dto.response.TraineeTrainingDetailResponseDTO">
+        SELECT t.title,
+               t.description,
+               t.price,
+               t.category,
+               t.level,
+               t.average_rating   AS averageRating,
+               t.trainee_count    AS traineeCount,
+               u.username         AS trainerNickname,
+               u.user_profile_url AS trainerProfileUrl,
+               t.thumbnail_url    AS thumbnailUrl
+        FROM trainings t
+                 JOIN users u ON t.trainer_id = u.user_id
+        WHERE t.training_id = #{trainingId}
+          AND t.approval_status = '승인'
+    </select>
+
+
 
 </mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #61 

## ✨️ 작업 내용
- [x] 승인된(approval_status='승인') 트레이닝 상세정보 조회 기능 추가(유저가 결제 전 상태)
- [x] 트레이너 정보(username, 프로필 이미지) 및 썸네일 URL 포함하여 응답

## 💙 코멘트 (선택)

## 📸 구현 결과 (선택)
<img width="539" height="520" alt="image" src="https://github.com/user-attachments/assets/2e720494-5325-4ae2-bb0b-4d79f54acdad" />
