### PR TITLE
[Feature] #65 : 회원의 마이페이지 수강목록 및 진행률 조회 API

### DIFF
--- a/src/main/java/com/kbulkup/training/controller/TraineeEnrollmentController.java
+++ b/src/main/java/com/kbulkup/training/controller/TraineeEnrollmentController.java
@@ -1,0 +1,4 @@
+package com.kbulkup.training.controller;
+
+public class TraineeEnrollmentController {
+}

--- a/src/main/java/com/kbulkup/training/controller/TraineeEnrollmentController.java
+++ b/src/main/java/com/kbulkup/training/controller/TraineeEnrollmentController.java
@@ -1,4 +1,34 @@
 package com.kbulkup.training.controller;
 
+import com.kbulkup.common.response.CustomResponse;
+import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.training.dto.response.TraineeEnrollmentResponseDTO;
+import com.kbulkup.training.service.TraineeEnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * [수강생] 수강 목록 및 진행률 조회 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trainee/enrollments")
 public class TraineeEnrollmentController {
+
+    private final TraineeEnrollmentService traineeEnrollmentService;
+
+    /**
+     *  수강생의 전체 수강 목록 조회
+     * - 진행률 계산 및 DB 업데이트 포함
+     * - RequestParam userId 사용 (JWT 추후 리팩토링 가능)
+     */
+    @GetMapping
+    public CustomResponse<List<TraineeEnrollmentResponseDTO>> getEnrollments(@RequestParam Long userId) {
+        return CustomResponse.success(
+                ResponseCode.SUCCESS,
+                traineeEnrollmentService.getEnrollments(userId)
+        );
+    }
 }

--- a/src/main/java/com/kbulkup/training/dto/response/TraineeEnrollmentResponseDTO.java
+++ b/src/main/java/com/kbulkup/training/dto/response/TraineeEnrollmentResponseDTO.java
@@ -1,0 +1,29 @@
+package com.kbulkup.training.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * [수강생] 수강 목록 응답 DTO
+ * - Lombok 사용 (Getter, AllArgsConstructor, NoArgsConstructor)
+ * - 팩토리 메서드 유지
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TraineeEnrollmentResponseDTO {
+
+    private Long trainingId;
+    private String title;
+    private String thumbnailUrl;
+    private float progress;
+    private LocalDateTime createdAt;
+
+    /**  팩토리 메서드 */
+    public static TraineeEnrollmentResponseDTO of(Long trainingId, String title, String thumbnailUrl, float progress, LocalDateTime createdAt) {
+        return new TraineeEnrollmentResponseDTO(trainingId, title, thumbnailUrl, progress, createdAt);
+    }
+}

--- a/src/main/java/com/kbulkup/training/mapper/TraineeEnrollmentMapper.java
+++ b/src/main/java/com/kbulkup/training/mapper/TraineeEnrollmentMapper.java
@@ -1,4 +1,35 @@
 package com.kbulkup.training.mapper;
 
-public class TraineeEnrollmentMapper {
+import com.kbulkup.training.dto.response.TraineeEnrollmentResponseDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * [수강생] 수강 목록 Mapper
+ * - DTO 직접 매핑 방식
+ */
+@Mapper
+public interface TraineeEnrollmentMapper {
+
+    /**
+     * 수강생 수강 목록 조회
+     */
+    List<TraineeEnrollmentResponseDTO> findTraineeEnrollments(Long userId);
+
+    /**
+     * 전체 루틴 수 조회
+     */
+    int countTotalRoutines(Long trainingId);
+
+    /**
+     * 완료된 루틴 수 조회
+     */
+    int countCompletedRoutines(@Param("trainingId") Long trainingId, @Param("userId") Long userId);
+
+    /**
+     * 진행률 업데이트
+     */
+    void updateTrainingProgress(@Param("trainingId") Long trainingId, @Param("userId") Long userId, @Param("progress") float progress);
 }

--- a/src/main/java/com/kbulkup/training/mapper/TraineeEnrollmentMapper.java
+++ b/src/main/java/com/kbulkup/training/mapper/TraineeEnrollmentMapper.java
@@ -1,0 +1,4 @@
+package com.kbulkup.training.mapper;
+
+public class TraineeEnrollmentMapper {
+}

--- a/src/main/java/com/kbulkup/training/service/TraineeEnrollmentService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeEnrollmentService.java
@@ -1,0 +1,4 @@
+package com.kbulkup.training.service;
+
+public class TraineeEnrollmentService {
+}

--- a/src/main/java/com/kbulkup/training/service/TraineeEnrollmentService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeEnrollmentService.java
@@ -1,4 +1,64 @@
 package com.kbulkup.training.service;
 
+import com.kbulkup.training.dto.response.TraineeEnrollmentResponseDTO;
+import com.kbulkup.training.mapper.TraineeEnrollmentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * [수강생] 수강 목록 서비스
+ * - 진행률 계산 및 DB 업데이트 포함
+ * - Mapper에서 DTO 매핑 후 Service에서 최신 진행률 갱신
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class TraineeEnrollmentService {
+
+    private final TraineeEnrollmentMapper traineeEnrollmentMapper;
+
+    /**
+     * 수강 목록 조회
+     * - DB에서 DTO 조회
+     * - 진행률 재계산 후 DB 업데이트
+     * - 최신 진행률로 DTO 재생성하여 반환
+     */
+    public List<TraineeEnrollmentResponseDTO> getEnrollments(Long userId) {
+        List<TraineeEnrollmentResponseDTO> enrollments = traineeEnrollmentMapper.findTraineeEnrollments(userId);
+        List<TraineeEnrollmentResponseDTO> responses = new ArrayList<>();
+
+        for (TraineeEnrollmentResponseDTO dto : enrollments) {
+            float updatedProgress = calculateAndUpdateProgress(dto.getTrainingId(), userId);
+
+            responses.add(
+                    TraineeEnrollmentResponseDTO.of(
+                            dto.getTrainingId(),
+                            dto.getTitle(),
+                            dto.getThumbnailUrl(),
+                            updatedProgress,   // ✅ 최신 진행률 적용
+                            dto.getCreatedAt()
+                    )
+            );
+        }
+        return responses;
+    }
+
+    /**
+     *  진행률 계산 및 DB 업데이트
+     * @param trainingId 트레이닝 ID
+     * @param userId     수강생 ID
+     * @return 계산된 진행률(%)
+     */
+    private float calculateAndUpdateProgress(Long trainingId, Long userId) {
+        int totalCount = traineeEnrollmentMapper.countTotalRoutines(trainingId);
+        int completedCount = traineeEnrollmentMapper.countCompletedRoutines(trainingId, userId);
+        float progress = (totalCount == 0) ? 0 : ((float) completedCount / totalCount) * 100;
+
+        traineeEnrollmentMapper.updateTrainingProgress(trainingId, userId, progress);
+        return progress;
+    }
 }

--- a/src/main/resources/mappers/training/TraineeEnrollmentMapper.xml
+++ b/src/main/resources/mappers/training/TraineeEnrollmentMapper.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kbulkup.training.mapper.TraineeEnrollmentMapper">
+
+    <!-- 수강생 수강 목록 DTO 매핑 -->
+    <select id="findTraineeEnrollments" parameterType="long"
+            resultType="com.kbulkup.training.dto.response.TraineeEnrollmentResponseDTO">
+        SELECT
+            t.training_id   AS trainingId,
+            t.title         AS title,
+            t.thumbnail_url AS thumbnailUrl,
+            e.progress      AS progress,
+            e.created_at    AS createdAt
+        FROM enrollments e
+                 JOIN trainings t ON e.training_id = t.training_id
+        WHERE e.user_id = #{userId}
+    </select>
+
+    <!-- 전체 루틴 수 -->
+    <select id="countTotalRoutines" resultType="int">
+        SELECT COUNT(*) FROM routines WHERE training_id = #{trainingId}
+    </select>
+
+    <!-- 완료된 루틴 수 -->
+    <select id="countCompletedRoutines" resultType="int">
+        SELECT COUNT(*)
+        FROM routine_results rr
+                 JOIN enrollments e ON rr.enrollment_id = e.enrollment_id
+        WHERE e.training_id = #{trainingId}
+          AND e.user_id = #{userId}
+          AND rr.status = TRUE
+    </select>
+
+    <!-- 진행률 업데이트 -->
+    <update id="updateTrainingProgress">
+        UPDATE enrollments
+        SET progress = #{progress}
+        WHERE training_id = #{trainingId}
+          AND user_id = #{userId}
+    </update>
+
+</mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #65 

## ✨️ 작업 내용
- [x] 회원이 마이페이지에서 수강목록을 확인 할 수 있는 기능 추가
- [x] 수강하고 있는 트레이닝의 수강진행률을 확인 할수 있는 기능 추가

## 💙 코멘트 (선택)
- 제 브랜치가 merge 되면, Pull받고 UserMapper.xml 수정 다시 부탁드립니다.

## 📸 구현 결과 (선택)
<img width="627" height="456" alt="image" src="https://github.com/user-attachments/assets/9f3ce75c-4910-47d0-b18c-b1771602cccf" />
