### PR TITLE
[Fix] #94 : 트레이니 자산 조회 API roomId 타입 Long에서 String으로 수정

### DIFF
--- a/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
+++ b/src/main/java/com/kbulkup/asset/controller/TraineeAssetController.java
@@ -35,7 +35,7 @@ public class TraineeAssetController {
     }
 
     @GetMapping("/trainer-share/{roomId}")
-    public CustomResponse<TraineeAssetDetailResponseDTO> getTraineeAssetToTrainer(@PathVariable Long roomId) {
+    public CustomResponse<TraineeAssetDetailResponseDTO> getTraineeAssetToTrainer(@PathVariable String roomId) {
         TraineeAssetDetailResponseDTO dto = traineeAssetService.findTraineeAssetDetailByRoomID(roomId);
         return CustomResponse.success(ResponseCode.SUCCESS, dto);
     }

--- a/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
+++ b/src/main/java/com/kbulkup/asset/mapper/TraineeAssetMapper.java
@@ -25,5 +25,5 @@ public interface TraineeAssetMapper {
 
     void insertComposition(@Param("traineeId") Long traineeId, @Param("composition") Composition composition);
 
-    Long findUserIdByRoomID(@Param("roomId") Long roomId);
+    Long findUserIdByRoomID(@Param("roomId") String roomId);
 }

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetService.java
@@ -8,5 +8,5 @@ public interface TraineeAssetService {
 
     void createUserPortfolio(String bank, Long id);
 
-    TraineeAssetDetailResponseDTO findTraineeAssetDetailByRoomID(Long roomId);
+    TraineeAssetDetailResponseDTO findTraineeAssetDetailByRoomID(String roomId);
 }

--- a/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
+++ b/src/main/java/com/kbulkup/asset/service/TraineeAssetServiceImpl.java
@@ -75,7 +75,7 @@ public class TraineeAssetServiceImpl implements TraineeAssetService {
     }
 
     @Override
-    public TraineeAssetDetailResponseDTO findTraineeAssetDetailByRoomID(Long roomId) {
+    public TraineeAssetDetailResponseDTO findTraineeAssetDetailByRoomID(String roomId) {
         Long userId = traineeAssetMapper.findUserIdByRoomID(roomId);
         return getTraineeAsset(userId);
     }

--- a/src/main/java/com/kbulkup/gpt/GptController.java
+++ b/src/main/java/com/kbulkup/gpt/GptController.java
@@ -2,6 +2,7 @@ package com.kbulkup.gpt;
 
 import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.gpt.dto.request.ConsultRequestDTO;
 import com.kbulkup.gpt.dto.response.GPTResponseDTO;
 import com.kbulkup.gpt.service.GPTService;
 import com.kbulkup.user.domain.User;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/gpt" )
 @RequiredArgsConstructor
-public class GptController { //테스트용 컨트롤러입니다.
+public class GptController {
 
     private final GPTService gptService;
 
@@ -29,8 +30,8 @@ public class GptController { //테스트용 컨트롤러입니다.
     }
 
     @PostMapping("/consulting")
-    public CustomResponse<GPTResponseDTO> requestConsultAsset(@RequestParam String question, @AuthenticationPrincipal(expression = "user") User user) {
-        GPTResponseDTO dto = gptService.requestCounseling(String.valueOf(user.getUserId()), question);
+    public CustomResponse<GPTResponseDTO> requestConsultAsset(@RequestBody ConsultRequestDTO consultRequestDTO, @AuthenticationPrincipal(expression = "user") User user) {
+        GPTResponseDTO dto = gptService.requestCounseling(String.valueOf(user.getUserId()), consultRequestDTO.getQuestion(), consultRequestDTO.isAsset());
         return CustomResponse.success(ResponseCode.SUCCESS, dto);
     }
 }

--- a/src/main/java/com/kbulkup/gpt/dto/request/ConsultRequestDTO.java
+++ b/src/main/java/com/kbulkup/gpt/dto/request/ConsultRequestDTO.java
@@ -1,0 +1,14 @@
+package com.kbulkup.gpt.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ConsultRequestDTO {
+
+    @JsonProperty("isAsset")
+    private boolean isAsset;
+
+    @JsonProperty("question")
+    private String question;
+}

--- a/src/main/java/com/kbulkup/gpt/service/GPTService.java
+++ b/src/main/java/com/kbulkup/gpt/service/GPTService.java
@@ -5,5 +5,5 @@ import com.kbulkup.gpt.dto.response.GPTResponseDTO;
 public interface GPTService {
     GPTResponseDTO requestOnlyText(String mission, String userAnswer);
     GPTResponseDTO requestImageAnalysis(String mission, String imageUrl);
-    GPTResponseDTO requestCounseling(String userId, String question);
+    GPTResponseDTO requestCounseling(String userId, String question, boolean isAsset);
 }

--- a/src/main/java/com/kbulkup/gpt/service/GPTServiceImpl.java
+++ b/src/main/java/com/kbulkup/gpt/service/GPTServiceImpl.java
@@ -43,8 +43,12 @@ public class GPTServiceImpl implements GPTService {
     }
 
     @Override
-    public GPTResponseDTO requestCounseling(String userId, String question) {
-        aiChatService.saveAiChatMessage(userId, question, "user");
+    public GPTResponseDTO requestCounseling(String userId, String question, boolean isAsset) {
+        if (isAsset) {
+            aiChatService.saveAiChatMessage(userId, "자산 정보를 전송했습니다.", "user");
+        } else {
+            aiChatService.saveAiChatMessage(userId, question, "user");
+        }
 
         String prompt = PromptBuilder.buildAssetConsultingPrompt(question);
         GPTRequestDTO gptRequestDTO = GPTRequestDTO.createOnlyText(apiModel, "user", prompt, 300);


### PR DESCRIPTION
## 📑 이슈 번호
- close #94

## ✨️ 작업 내용
- [x] TraineeAssetController#getTraineeAssetToTrainer 메소드에서 roomId 파라미터 타입을 Long에서 String으로 변경.
- [x] 관련 Service, Mapper도 String으로 수정

## 💙 코멘트 (선택)

## 📸 구현 결과 (선택)
