### PR TITLE
[Feature] #104 : Redis, MongoDB Docker 컨테이너화를 통한 로컬 개발환경 표준화

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  mongodb:
+    image: mongo:7.0
+    container_name: kbulkup-mongodb
+    restart: always
+    ports:
+      - "27018:27017"
+    environment:
+      MONGO_INITDB_DATABASE: chatdb
+    volumes:
+      - mongodb_data:/data/db
+    networks:
+      - kbulkup-network
+
+  redis:
+    image: redis:7.2-alpine
+    container_name: kbulkup-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - kbulkup-network
+
+volumes:
+  mongodb_data:
+  redis_data:
+
+networks:
+  kbulkup-network:
+    driver: bridge

--- a/src/main/java/com/kbulkup/common/config/MongoConfig.java
+++ b/src/main/java/com/kbulkup/common/config/MongoConfig.java
@@ -2,6 +2,7 @@ package com.kbulkup.common.config;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -9,16 +10,19 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 @Configuration
 public class MongoConfig {
 
-    private static final String CONNECTION_STRING = "mongodb://localhost:27017";
-    private static final String DATABASE_NAME = "chatdb";
+    @Value("${spring.data.mongodb.uri}")
+    private String mongoUri;
+
+    @Value("${spring.data.mongodb.database}")
+    private String databaseName;
 
     @Bean
     public MongoClient mongoClient() {
-        return MongoClients.create(CONNECTION_STRING);
+        return MongoClients.create(mongoUri);
     }
 
     @Bean
     public MongoTemplate mongoTemplate() {
-        return new MongoTemplate(mongoClient(), DATABASE_NAME);
+        return new MongoTemplate(mongoClient(), databaseName);
     }
 }

--- a/src/main/java/com/kbulkup/common/config/SecurityConfig.java
+++ b/src/main/java/com/kbulkup/common/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/api/common/auth/social-signup-complete" // 소셜 회원가입 완료 엔드포인트
                 ).permitAll()
                 .antMatchers(HttpMethod.OPTIONS, "/api/common/auth/**").permitAll()
+                .antMatchers("/api/trainee/assets/trainer-share/**").hasAuthority("TRAINER")
                 .antMatchers("/api/trainer/**").hasAuthority("TRAINER")
                 .antMatchers("/api/trainee/**").hasAuthority("TRAINEE")
                 .antMatchers("/api/common/**").hasAnyAuthority("TRAINER", "TRAINEE")


### PR DESCRIPTION
## 📑 이슈 번호
- close #104 

## ✨️ 작업 내용
- [x] Docker Compose 파일 생성 (Redis, MongoDB 서비스 정의)
- [x] 기존 MongoConfig 클래스에서 하드코딩된 연결 정보 제거 및 properties 파일에 추가
- [x] Docker 컨테이너 실행을 위한 스크립트 작성
  - Redis, MongoDB 컨테이너화 구성
  - MongoDB 포트 충돌 방지를 위해 27018 포트 사용
- [x] 컨테이너 환경에서의 연결 테스트 및 검증

## 💙 코멘트 (선택)

- `Docker Desktop`에 `docker-compose`가 포함되어 있기 때문에 `Docker Desktop`만 다운로드하시면 됩니다
- [Docker Desktop 공식 사이트](https://www.docker.com/products/docker-desktop/)

```shell
# 컨테이너 백 그라운드 실행
$ docker-compose -f docker-compose.dev.yml up -d

# 컨테이너 중지 & 제거
$ docker-compose -f docker-compose.dev.yml down
```

## 📸 구현 결과 (선택)
<img width="1065" height="76" alt="image" src="https://github.com/user-attachments/assets/00b40d73-f267-4fa0-b28d-99ed62fa3245" />
