### PR TITLE
[Refactor] #112 : 페이지와 API 연동 후 누락된 기능 추가 및 수정

### DIFF
--- a/src/main/java/com/kbulkup/common/config/PortOneConfig.java
+++ b/src/main/java/com/kbulkup/common/config/PortOneConfig.java
@@ -3,17 +3,27 @@ package com.kbulkup.common.config;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 @Getter
 @Configuration
+@PropertySource("classpath:config/application-dev.properties") // ✅ resources/config 로드 강제
 public class PortOneConfig {
 
-    @Value("${portone.api.key}")
-    private String apiKey;
+    private final String apiKey;
+    private final String apiSecret;
+    private final String baseUrl;
 
-    @Value("${portone.api.secret}")
-    private String apiSecret;
+    public PortOneConfig(
+            @Value("${PORTONE_API_KEY:#{null}}") String envApiKey,
+            @Value("${portone.api.key:#{null}}") String propApiKey,
+            @Value("${PORTONE_API_SECRET:#{null}}") String envApiSecret,
+            @Value("${portone.api.secret:#{null}}") String propApiSecret,
+            @Value("${portone.api.url:https://api.iamport.kr}") String propBaseUrl) {
 
-    @Value("${portone.api.url}")
-    private String baseUrl;
+        // 환경변수가 우선, 없으면 properties fallback
+        this.apiKey = envApiKey != null ? envApiKey : propApiKey;
+        this.apiSecret = envApiSecret != null ? envApiSecret : propApiSecret;
+        this.baseUrl = propBaseUrl; // URL은 기본값 제공
+    }
 }

--- a/src/main/java/com/kbulkup/payment/client/PortOneClient.java
+++ b/src/main/java/com/kbulkup/payment/client/PortOneClient.java
@@ -7,6 +7,7 @@ import com.kbulkup.common.response.ResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -14,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PortOneClient {
@@ -31,6 +33,7 @@ public class PortOneClient {
             return cachedToken;
         }
 
+        log.info("[PortOneClient] AccessToken 요청 시도...");
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -46,20 +49,22 @@ public class PortOneClient {
                     TokenResponse.class
             );
 
-            TokenResponse.TokenData data = response.getBody() != null ? response.getBody().getResponse() : null;
+            TokenResponse.TokenData data = (response.getBody() != null) ? response.getBody().getResponse() : null;
             if (data == null || data.getAccessToken() == null) {
+                log.error("[PortOneClient] 토큰 응답 데이터 없음");
                 throw new BaseException(ResponseCode.PAYMENT_VERIFICATION_FAILED);
             }
 
             cachedToken = data.getAccessToken();
-            tokenExpiry = Instant.now().plusSeconds(data.getExpiredAt());
+            tokenExpiry = Instant.ofEpochSecond(data.getExpiredAt());
+            log.info("[PortOneClient] AccessToken 발급 성공, 만료시간={}", tokenExpiry);
             return cachedToken;
 
         } catch (HttpClientErrorException e) {
-            //  포트원 인증 오류를 CustomResponse 대응 예외로 변환
+            log.error("[PortOneClient] 포트원 인증 오류: {}", e.getMessage());
             throw new BaseException(ResponseCode.PAYMENT_VERIFICATION_FAILED);
         } catch (Exception e) {
-            //  기타 예외도 CustomResponse 대응 예외로 변환
+            log.error("[PortOneClient] AccessToken 발급 실패", e);
             throw new BaseException(ResponseCode.PAYMENT_PROCESS_FAILED);
         }
     }
@@ -73,7 +78,7 @@ public class PortOneClient {
 
             RestTemplate restTemplate = new RestTemplate();
             HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", token);
+            headers.set("Authorization", "Bearer " + token); //  Bearer prefix 추가
             HttpEntity<Void> entity = new HttpEntity<>(headers);
 
             ResponseEntity<PaymentVerificationResponse> response = restTemplate.exchange(
@@ -83,12 +88,16 @@ public class PortOneClient {
                     PaymentVerificationResponse.class
             );
 
-            var res = response.getBody().getResponse();
-            return new PaymentResult(res.getStatus().equals("paid"), res.getAmount(), res.getPayMethod(), res.getPaidAt());
+            PaymentVerificationResponse.PaymentData res = response.getBody().getResponse();
+            log.info("[PortOneClient] 결제 검증 성공: impUid={}, status={}", impUid, res.getStatus());
+
+            return new PaymentResult("paid".equals(res.getStatus()), res.getAmount(), res.getPayMethod(), res.getPaidAt());
 
         } catch (HttpClientErrorException e) {
+            log.error("[PortOneClient] 결제 검증 실패(포트원 응답 오류): {}", e.getMessage());
             throw new BaseException(ResponseCode.PAYMENT_VERIFICATION_FAILED);
         } catch (Exception e) {
+            log.error("[PortOneClient] 결제 검증 실패", e);
             throw new BaseException(ResponseCode.PAYMENT_PROCESS_FAILED);
         }
     }
@@ -106,11 +115,11 @@ public class PortOneClient {
             private long expiredAt;
 
             public String getAccessToken() { return accessToken; }
-            public long getExpiredAt() { return expiredAt - Instant.now().getEpochSecond(); }
+            public long getExpiredAt() { return expiredAt; } //  UNIX Timestamp 그대로 반환
         }
     }
 
-    /** 결제 검증 응답 DTO */
+    /**  결제 검증 응답 DTO */
     private static class PaymentVerificationResponse {
         @JsonProperty("response")
         private PaymentData response;

--- a/src/main/java/com/kbulkup/payment/mapper/TraineeTrainingPaymentMapper.java
+++ b/src/main/java/com/kbulkup/payment/mapper/TraineeTrainingPaymentMapper.java
@@ -12,4 +12,9 @@ public interface TraineeTrainingPaymentMapper {
      * @param trainingId 결제한 강의 ID
      */
     void insertEnrollment(@Param("userId") Long userId, @Param("trainingId") Long trainingId);
+
+    Long findEnrollmentId(@Param("userId") Long userId, @Param("trainingId") Long trainingId);
+
+    void insertRoutineResultsForEnrollment(@Param("enrollmentId") Long enrollmentId,
+                                           @Param("trainingId") Long trainingId);
 }

--- a/src/main/java/com/kbulkup/payment/service/TraineeTrainingPaymentServiceImpl.java
+++ b/src/main/java/com/kbulkup/payment/service/TraineeTrainingPaymentServiceImpl.java
@@ -28,7 +28,13 @@ public class TraineeTrainingPaymentServiceImpl implements TraineeTrainingPayment
         //  2. enrollments 테이블에 신규 등록
         paymentMapper.insertEnrollment(requestDTO.getUserId(), requestDTO.getTrainingId());
 
-        //  3. 성공 응답 반환
+        //  3. 새로 생성된 enrollment_id 조회
+        Long enrollmentId = paymentMapper.findEnrollmentId(requestDTO.getUserId(), requestDTO.getTrainingId());
+
+        //  4. routine_results 초기화
+        paymentMapper.insertRoutineResultsForEnrollment(enrollmentId, requestDTO.getTrainingId());
+
+        // 5. 성공 응답 반환
         return TraineeTrainingPaymentResponseDTO.ofSuccess(
                 result.getPaidAt(),
                 result.getMethod(),

--- a/src/main/java/com/kbulkup/routine/dto/RoutineSummaryResponseDTO.java
+++ b/src/main/java/com/kbulkup/routine/dto/RoutineSummaryResponseDTO.java
@@ -8,13 +8,14 @@ import lombok.AllArgsConstructor;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class RoutineSummaryResponseDTO {
     private Long routineId;
     private String title;
     private boolean completed;
     private int rewardPoint;
     private LocalDateTime completedAt;
+    private String routineType;
 }

--- a/src/main/java/com/kbulkup/routine/dto/TraineeRoutineSummaryResponseDTO.java
+++ b/src/main/java/com/kbulkup/routine/dto/TraineeRoutineSummaryResponseDTO.java
@@ -1,14 +1,16 @@
 package com.kbulkup.routine.dto;
 
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
 public class TraineeRoutineSummaryResponseDTO {
 
     private String title;
@@ -21,74 +23,16 @@ public class TraineeRoutineSummaryResponseDTO {
     private int traineeCount;
     private float progress;
 
-    private List<RoutineSummaryResponseDTO> routines;
-
-    @Builder
-    private TraineeRoutineSummaryResponseDTO(String title, String description, int price, String category,
-                                             String level, int totalScore, float averageRating,
-                                             int traineeCount, float progress,
-                                             List<RoutineSummaryResponseDTO> routines) {
-        this.title = title;
-        this.description = description;
-        this.price = price;
-        this.category = category;
-        this.level = level;
-        this.totalScore = totalScore;
-        this.averageRating = averageRating;
-        this.traineeCount = traineeCount;
-        this.progress = progress;
-        this.routines = routines;
-    }
-
-    /** 팩토리 메소드 추가 */
-    public static TraineeRoutineSummaryResponseDTO of(String title, String description, int price, String category,
-                                                      String level, int totalScore, float averageRating,
-                                                      int traineeCount, float progress,
-                                                      List<RoutineSummaryResponseDTO> routines) {
-        return TraineeRoutineSummaryResponseDTO.builder()
-                .title(title)
-                .description(description)
-                .price(price)
-                .category(category)
-                .level(level)
-                .totalScore(totalScore)
-                .averageRating(averageRating)
-                .traineeCount(traineeCount)
-                .progress(progress)
-                .routines(routines)
-                .build();
-    }
+    // 루틴 타입별 Map
+    private Map<String, List<RoutineSummaryResponseDTO>> routines;
 
     @Getter
-    @NoArgsConstructor
+    @AllArgsConstructor(staticName = "of")
     public static class RoutineSummaryResponseDTO {
-
         private Long routineId;
         private String title;
         private boolean completed;
         private int rewardPoint;
         private LocalDateTime completedAt;
-
-        @Builder
-        private RoutineSummaryResponseDTO(Long routineId, String title, boolean completed,
-                                          int rewardPoint, LocalDateTime completedAt) {
-            this.routineId = routineId;
-            this.title = title;
-            this.completed = completed;
-            this.rewardPoint = rewardPoint;
-            this.completedAt = completedAt;
-        }
-
-        /** 루틴용 팩토리 메소드 추가 */
-        public static RoutineSummaryResponseDTO of(Long routineId, String title, boolean completed,
-                                                   int rewardPoint, LocalDateTime completedAt) {
-            return RoutineSummaryResponseDTO.builder()
-                    .routineId(routineId)
-                    .title(title)
-                    .completed(completed)
-                    .rewardPoint(rewardPoint)
-                    .completedAt(completedAt)
-                    .build();
-        }
     }
 }

--- a/src/main/java/com/kbulkup/routine/dto/TraineeRoutineSummaryResponseDTO.java
+++ b/src/main/java/com/kbulkup/routine/dto/TraineeRoutineSummaryResponseDTO.java
@@ -22,6 +22,9 @@ public class TraineeRoutineSummaryResponseDTO {
     private float averageRating;
     private int traineeCount;
     private float progress;
+    // 트레이너 정보 추가
+    private String trainerNickname;
+    private String trainerProfileUrl;
 
     // 루틴 타입별 Map
     private Map<String, List<RoutineSummaryResponseDTO>> routines;

--- a/src/main/java/com/kbulkup/training/controller/TrainingController.java
+++ b/src/main/java/com/kbulkup/training/controller/TrainingController.java
@@ -33,95 +33,63 @@ public class TrainingController {
     private final TrainingSearchService trainingSearchService;
     private final TraineeTrainingService traineeTrainingService;
 
-    /**
-     * [트레이너] 트레이닝 생성
-     */
+    /** [트레이너] 트레이닝 생성 */
     @PostMapping("/trainer/trainings")
     public ResponseEntity<CustomResponse<Void>> createTraining(
             @AuthenticationPrincipal(expression = "user") User user,
             @RequestPart("dto") TrainerTrainingCreateRequestDTO dto,
             @RequestPart("thumbnail") MultipartFile thumbnail
     ) throws IOException {
-
         trainingService.createTraining(user.getUserId(), dto, thumbnail);
         return ResponseEntity.ok(CustomResponse.success(ResponseCode.SUCCESS));
     }
 
-    /**
-     * [공용] 트레이닝 검색
-     */
+    /** [공용] 트레이닝 검색 */
     @GetMapping("/trainings/search")
     public CustomResponse<List<TrainingSearchListResponseDTO>> searchTrainings(
             @ModelAttribute TrainingSearchListRequestDTO dto) {
         return CustomResponse.success(ResponseCode.SUCCESS, trainingSearchService.searchTrainings(dto));
     }
 
-    /**
-     * [수강생] 트레이닝 실행(결제 후) 상세 조회 (기존 API, 유지)
-     */
+    /** [수강생] 트레이닝 실행(결제 후) 상세 조회 */
     @GetMapping("/trainee/trainings/running/{trainingId}")
     public CustomResponse<TraineeRoutineSummaryResponseDTO> getRunningTrainingDetail(
             @PathVariable Long trainingId,
             @AuthenticationPrincipal(expression = "user") User user) {
-
-        // request DTO 생성
         var request = new TraineeTrainingDetailRequestDTO(trainingId);
-
-        // 서비스의 공개 메서드 getTrainingDetail 호출 후 캐스팅
         TraineeRoutineSummaryResponseDTO detail =
                 (TraineeRoutineSummaryResponseDTO) traineeTrainingService.getTrainingDetail(request, user.getUserId());
-
         return CustomResponse.success(ResponseCode.SUCCESS, detail);
     }
 
-    /**
-     * [수강생] 트레이닝 탭 전체 목록 조회
-     */
-    @GetMapping("/trainee/trainings/training")
-    public CustomResponse<List<TraineeTrainingListResponseDTO>> getAllTrainings(
-            @AuthenticationPrincipal(expression = "user") User user) {
-        return CustomResponse.success(
-                ResponseCode.SUCCESS,
-                traineeTrainingService.getAllApprovedTrainings(user.getUserId())
-        );
-    }
-
-    /**
-     * [수강생] 트레이닝 상세 조회
-     * - 서비스에서 결제 여부를 판별하도록 변경
-     * - 반환 타입은 Object (결제 여부에 따라 DTO가 다르므로)
-     */
+    /** [수강생] 트레이닝 상세 조회 (결제 여부 서비스에서 판별) */
     @GetMapping("/trainee/trainings/{trainingId}")
     public CustomResponse<Object> getTrainingDetail(
             @PathVariable Long trainingId,
             @AuthenticationPrincipal(expression = "user") User user) {
-
-        var dto = new TraineeTrainingDetailRequestDTO(trainingId);
-        Object detailResponse = traineeTrainingService.getTrainingDetail(dto, user.getUserId());
-
-        return CustomResponse.success(ResponseCode.SUCCESS, detailResponse);
+        var request = new TraineeTrainingDetailRequestDTO(trainingId);
+        return CustomResponse.success(ResponseCode.SUCCESS, traineeTrainingService.getTrainingDetail(request, user.getUserId()));
     }
 
-    /**
-     * [수강생] 트레이닝 리뷰 조회
-     */
+    /** [수강생] 트레이닝 탭 전체 목록 조회 */
+    @GetMapping("/trainee/trainings/training")
+    public CustomResponse<List<TraineeTrainingListResponseDTO>> getAllTrainings(
+            @AuthenticationPrincipal(expression = "user") User user) {
+        return CustomResponse.success(ResponseCode.SUCCESS, traineeTrainingService.getAllApprovedTrainings(user.getUserId()));
+    }
+
+    /** [수강생] 트레이닝 리뷰 조회 */
     @GetMapping("/trainee/trainings/reviews/{trainingId}")
     public CustomResponse<TraineeTrainingReviewResponseDTO> getTrainingReview(@PathVariable Long trainingId) {
-        return CustomResponse.success(
-                ResponseCode.SUCCESS,
-                traineeTrainingService.getTrainingTitle(trainingId)
-        );
+        return CustomResponse.success(ResponseCode.SUCCESS, traineeTrainingService.getTrainingTitle(trainingId));
     }
 
-    /**
-     * [수강생] 트레이닝 리뷰 작성
-     */
+    /** [수강생] 트레이닝 리뷰 작성 */
     @PostMapping("/trainee/trainings/reviews/{trainingId}")
     public CustomResponse<Void> createTrainingReview(
             @AuthenticationPrincipal(expression = "user") User user,
             @PathVariable Long trainingId,
             @RequestBody TraineeTrainingReviewCreateDTO dto) {
-
         traineeTrainingService.createReview(user.getUserId(), trainingId, dto);
         return CustomResponse.success(ResponseCode.SUCCESS);
     }

--- a/src/main/java/com/kbulkup/training/controller/TrainingController.java
+++ b/src/main/java/com/kbulkup/training/controller/TrainingController.java
@@ -1,6 +1,5 @@
 package com.kbulkup.training.controller;
 
-import com.kbulkup.asset.dto.response.TraineeAssetDetailResponseDTO;
 import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.common.response.ResponseCode;
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
@@ -39,13 +38,12 @@ public class TrainingController {
      */
     @PostMapping("/trainer/trainings")
     public ResponseEntity<CustomResponse<Void>> createTraining(
-            @AuthenticationPrincipal(expression = "user") User user, // 로그인한 사용자 정보
-            @RequestPart("dto") TrainerTrainingCreateRequestDTO dto,       // JSON 데이터 부분
-            @RequestPart("thumbnail") MultipartFile thumbnail           // 파일 데이터 부분
+            @AuthenticationPrincipal(expression = "user") User user,
+            @RequestPart("dto") TrainerTrainingCreateRequestDTO dto,
+            @RequestPart("thumbnail") MultipartFile thumbnail
     ) throws IOException {
 
         trainingService.createTraining(user.getUserId(), dto, thumbnail);
-
         return ResponseEntity.ok(CustomResponse.success(ResponseCode.SUCCESS));
     }
 
@@ -59,49 +57,71 @@ public class TrainingController {
     }
 
     /**
-     * [수강생] 트레이닝 실행(결제 후) 상세 조회
+     * [수강생] 트레이닝 실행(결제 후) 상세 조회 (기존 API, 유지)
      */
     @GetMapping("/trainee/trainings/running/{trainingId}")
     public CustomResponse<TraineeRoutineSummaryResponseDTO> getRunningTrainingDetail(
             @PathVariable Long trainingId,
             @AuthenticationPrincipal(expression = "user") User user) {
 
-        return CustomResponse.success(
-                ResponseCode.SUCCESS,
-                traineeTrainingService.getTrainingDetail(trainingId, user.getUserId())
-        );
+        // request DTO 생성
+        var request = new TraineeTrainingDetailRequestDTO(trainingId);
+
+        // 서비스의 공개 메서드 getTrainingDetail 호출 후 캐스팅
+        TraineeRoutineSummaryResponseDTO detail =
+                (TraineeRoutineSummaryResponseDTO) traineeTrainingService.getTrainingDetail(request, user.getUserId());
+
+        return CustomResponse.success(ResponseCode.SUCCESS, detail);
     }
 
     /**
      * [수강생] 트레이닝 탭 전체 목록 조회
      */
     @GetMapping("/trainee/trainings/training")
-    public CustomResponse<List<TraineeTrainingListResponseDTO>> getAllTrainings() {
+    public CustomResponse<List<TraineeTrainingListResponseDTO>> getAllTrainings(
+            @AuthenticationPrincipal(expression = "user") User user) {
         return CustomResponse.success(
                 ResponseCode.SUCCESS,
-                traineeTrainingService.getAllApprovedTrainings()
+                traineeTrainingService.getAllApprovedTrainings(user.getUserId())
         );
     }
 
     /**
-     * [수강생] 트레이닝 상세 조회 (결제 전)
+     * [수강생] 트레이닝 상세 조회
+     * - 서비스에서 결제 여부를 판별하도록 변경
+     * - 반환 타입은 Object (결제 여부에 따라 DTO가 다르므로)
      */
     @GetMapping("/trainee/trainings/{trainingId}")
-    public CustomResponse<TraineeTrainingDetailResponseDTO> getTrainingDetail(@PathVariable Long trainingId) {
+    public CustomResponse<Object> getTrainingDetail(
+            @PathVariable Long trainingId,
+            @AuthenticationPrincipal(expression = "user") User user) {
+
+        var dto = new TraineeTrainingDetailRequestDTO(trainingId);
+        Object detailResponse = traineeTrainingService.getTrainingDetail(dto, user.getUserId());
+
+        return CustomResponse.success(ResponseCode.SUCCESS, detailResponse);
+    }
+
+    /**
+     * [수강생] 트레이닝 리뷰 조회
+     */
+    @GetMapping("/trainee/trainings/reviews/{trainingId}")
+    public CustomResponse<TraineeTrainingReviewResponseDTO> getTrainingReview(@PathVariable Long trainingId) {
         return CustomResponse.success(
                 ResponseCode.SUCCESS,
-                traineeTrainingService.getTrainingDetail(new TraineeTrainingDetailRequestDTO(trainingId))
+                traineeTrainingService.getTrainingTitle(trainingId)
         );
     }
 
-    @GetMapping("/trainee/trainings/reviews/{trainingId}")
-    public CustomResponse<TraineeTrainingReviewResponseDTO> getTrainingReview(@PathVariable Long trainingId) {
-        TraineeTrainingReviewResponseDTO dto = traineeTrainingService.getTrainingTitle(trainingId);
-        return CustomResponse.success(ResponseCode.SUCCESS, dto);
-    }
-
+    /**
+     * [수강생] 트레이닝 리뷰 작성
+     */
     @PostMapping("/trainee/trainings/reviews/{trainingId}")
-    public CustomResponse<Void> getTraineeAsset(@AuthenticationPrincipal(expression = "user") User user, @PathVariable Long trainingId, @RequestBody TraineeTrainingReviewCreateDTO dto) {
+    public CustomResponse<Void> createTrainingReview(
+            @AuthenticationPrincipal(expression = "user") User user,
+            @PathVariable Long trainingId,
+            @RequestBody TraineeTrainingReviewCreateDTO dto) {
+
         traineeTrainingService.createReview(user.getUserId(), trainingId, dto);
         return CustomResponse.success(ResponseCode.SUCCESS);
     }

--- a/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingListResponseDTO.java
+++ b/src/main/java/com/kbulkup/training/dto/response/TraineeTrainingListResponseDTO.java
@@ -17,4 +17,5 @@ public class TraineeTrainingListResponseDTO {
     private String thumbnailUrl;
     private String level;
     private String category;
+    private boolean purchased;
 }

--- a/src/main/java/com/kbulkup/training/mapper/TraineeTrainingMapper.java
+++ b/src/main/java/com/kbulkup/training/mapper/TraineeTrainingMapper.java
@@ -29,7 +29,9 @@ public interface TraineeTrainingMapper {
                                 @Param("userId") Long userId,
                                 @Param("progress") int progress);
 
-    List<TraineeTrainingListResponseDTO> findAllApprovedTrainings();
+    boolean isTrainingPurchased(@Param("trainingId") Long trainingId, @Param("userId") Long userId);
+
+    List<TraineeTrainingListResponseDTO> findAllApprovedTrainings(@Param("userId") Long userId);
 
     /**  결제 전 트레이닝 상세 조회 (루틴 총점수 포함) */
     TraineeTrainingDetailResponseDTO findTrainingDetail(@Param("trainingId") Long trainingId);

--- a/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
@@ -2,6 +2,7 @@ package com.kbulkup.training.service;
 
 import com.kbulkup.common.exception.BaseException;
 import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.routine.dto.RoutineSummaryResponseDTO;
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
 import com.kbulkup.training.dto.request.TraineeTrainingDetailRequestDTO;
 import com.kbulkup.training.dto.request.TraineeTrainingReviewCreateDTO;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,48 +24,33 @@ public class TraineeTrainingService {
 
     private final TraineeTrainingMapper traineeTrainingMapper;
 
-    /**
-     * 트레이닝 상세 조회 (결제 여부 판별 후 적절한 DTO 반환)
-     * - userId가 있고, 결제된 경우: TraineeRoutineSummaryResponseDTO 반환
-     * - 결제되지 않은 경우: TraineeTrainingDetailResponseDTO 반환
-     */
+    /** 결제 여부에 따라 다른 DTO 반환 */
     public Object getTrainingDetail(TraineeTrainingDetailRequestDTO request, Long userId) {
-
         boolean purchased = traineeTrainingMapper.isTrainingPurchased(request.getTrainingId(), userId);
-
-        if (purchased) {
-            return getPurchasedTrainingDetail(request, userId);
-        } else {
-            return getUnpurchasedTrainingDetail(request);
-        }
+        return purchased ? getPurchasedTrainingDetail(request, userId) : getUnpurchasedTrainingDetail(request);
     }
 
-    /**
-     * [결제 후] 트레이닝 상세 조회 (팩토리 메서드 적용)
-     */
+    /** 결제 후 상세 조회 (루틴 타입별 Map 사용) */
     private TraineeRoutineSummaryResponseDTO getPurchasedTrainingDetail(TraineeTrainingDetailRequestDTO request, Long userId) {
         var training = traineeTrainingMapper.findTrainingById(request.getTrainingId(), userId);
+        if (training == null) throw new BaseException(ResponseCode.TRAINING_NOT_FOUND);
 
-        if (training == null) {
-            throw new BaseException(ResponseCode.TRAINING_NOT_FOUND);
-        }
+        var routines = traineeTrainingMapper.findRoutinesByTraining(request.getTrainingId(), userId);
 
-        var routines = traineeTrainingMapper.findRoutinesByTraining(request.getTrainingId(), userId).stream()
-                .map(r -> TraineeRoutineSummaryResponseDTO.RoutineSummaryResponseDTO.of(
-                        r.getRoutineId(),
-                        r.getTitle(),
-                        r.isCompleted(),
-                        r.getRewardPoint(),
-                        r.getCompletedAt()
-                )).toList();
+        //  routineType 기준 그룹핑
+        Map<String, List<TraineeRoutineSummaryResponseDTO.RoutineSummaryResponseDTO>> groupedRoutines =
+                routines.stream().collect(Collectors.groupingBy(
+                        RoutineSummaryResponseDTO::getRoutineType,
+                        Collectors.mapping(r -> TraineeRoutineSummaryResponseDTO.RoutineSummaryResponseDTO.of(
+                                r.getRoutineId(), r.getTitle(), r.isCompleted(), r.getRewardPoint(), r.getCompletedAt()
+                        ), Collectors.toList())
+                ));
 
         int completedCount = traineeTrainingMapper.countCompletedRoutines(request.getTrainingId(), userId);
         int totalCount = traineeTrainingMapper.countTotalRoutines(request.getTrainingId());
         float progress = (totalCount == 0) ? 0 : ((float) completedCount / totalCount) * 100;
-
         int totalRoutineScore = traineeTrainingMapper.sumRoutineScore(request.getTrainingId());
 
-        // 팩토리 메서드 사용
         return TraineeRoutineSummaryResponseDTO.of(
                 training.getTitle(),
                 training.getDescription(),
@@ -73,34 +61,23 @@ public class TraineeTrainingService {
                 training.getAverageRating(),
                 training.getTraineeCount(),
                 progress,
-                routines
+                groupedRoutines
         );
     }
 
-    /**
-     * [결제 전] 트레이닝 상세 조회 (Mapper → DTO 그대로 반환)
-     */
+    /** 결제 전 상세 조회 */
     private TraineeTrainingDetailResponseDTO getUnpurchasedTrainingDetail(TraineeTrainingDetailRequestDTO request) {
         return traineeTrainingMapper.findTrainingDetail(request.getTrainingId());
     }
 
-    /**
-     * 전체 트레이닝 목록 조회
-     */
     public List<TraineeTrainingListResponseDTO> getAllApprovedTrainings(Long userId) {
         return traineeTrainingMapper.findAllApprovedTrainings(userId);
     }
 
-    /**
-     * 트레이닝 제목 조회
-     */
     public TraineeTrainingReviewResponseDTO getTrainingTitle(Long trainingId) {
         return traineeTrainingMapper.findTrainingTitleByTrainingId(trainingId);
     }
 
-    /**
-     * 리뷰 작성
-     */
     @Transactional
     public void createReview(Long userId, Long trainingId, TraineeTrainingReviewCreateDTO dto) {
         traineeTrainingMapper.insertReview(userId, trainingId, dto.getRating(), dto.getContent());

--- a/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
@@ -2,7 +2,6 @@ package com.kbulkup.training.service;
 
 import com.kbulkup.common.exception.BaseException;
 import com.kbulkup.common.response.ResponseCode;
-import com.kbulkup.common.response.CustomResponse;
 import com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO;
 import com.kbulkup.training.dto.request.TraineeTrainingDetailRequestDTO;
 import com.kbulkup.training.dto.request.TraineeTrainingReviewCreateDTO;
@@ -23,16 +22,32 @@ public class TraineeTrainingService {
     private final TraineeTrainingMapper traineeTrainingMapper;
 
     /**
-     *  결제 후 트레이닝 상세 조회
-     * - Mapper에서 받은 데이터를 DTO로 변환 후 반환
+     * 트레이닝 상세 조회 (결제 여부 판별 후 적절한 DTO 반환)
+     * - userId가 있고, 결제된 경우: TraineeRoutineSummaryResponseDTO 반환
+     * - 결제되지 않은 경우: TraineeTrainingDetailResponseDTO 반환
      */
-    public TraineeRoutineSummaryResponseDTO getTrainingDetail(Long trainingId, Long userId) {
-        var training = traineeTrainingMapper.findTrainingById(trainingId, userId);
+    public Object getTrainingDetail(TraineeTrainingDetailRequestDTO request, Long userId) {
+
+        boolean purchased = traineeTrainingMapper.isTrainingPurchased(request.getTrainingId(), userId);
+
+        if (purchased) {
+            return getPurchasedTrainingDetail(request, userId);
+        } else {
+            return getUnpurchasedTrainingDetail(request);
+        }
+    }
+
+    /**
+     * [결제 후] 트레이닝 상세 조회 (팩토리 메서드 적용)
+     */
+    private TraineeRoutineSummaryResponseDTO getPurchasedTrainingDetail(TraineeTrainingDetailRequestDTO request, Long userId) {
+        var training = traineeTrainingMapper.findTrainingById(request.getTrainingId(), userId);
+
         if (training == null) {
             throw new BaseException(ResponseCode.TRAINING_NOT_FOUND);
         }
 
-        var routines = traineeTrainingMapper.findRoutinesByTraining(trainingId, userId).stream()
+        var routines = traineeTrainingMapper.findRoutinesByTraining(request.getTrainingId(), userId).stream()
                 .map(r -> TraineeRoutineSummaryResponseDTO.RoutineSummaryResponseDTO.of(
                         r.getRoutineId(),
                         r.getTitle(),
@@ -41,13 +56,13 @@ public class TraineeTrainingService {
                         r.getCompletedAt()
                 )).toList();
 
-        int completedCount = traineeTrainingMapper.countCompletedRoutines(trainingId, userId);
-        int totalCount = traineeTrainingMapper.countTotalRoutines(trainingId);
+        int completedCount = traineeTrainingMapper.countCompletedRoutines(request.getTrainingId(), userId);
+        int totalCount = traineeTrainingMapper.countTotalRoutines(request.getTrainingId());
         float progress = (totalCount == 0) ? 0 : ((float) completedCount / totalCount) * 100;
 
-        //  총점수 DB에서 합산
-        int totalRoutineScore = traineeTrainingMapper.sumRoutineScore(trainingId);
+        int totalRoutineScore = traineeTrainingMapper.sumRoutineScore(request.getTrainingId());
 
+        // 팩토리 메서드 사용
         return TraineeRoutineSummaryResponseDTO.of(
                 training.getTitle(),
                 training.getDescription(),
@@ -63,20 +78,29 @@ public class TraineeTrainingService {
     }
 
     /**
-     *  결제 전 트레이닝 상세 조회
-     * - Mapper 반환을 그대로 DTO로 사용
+     * [결제 전] 트레이닝 상세 조회 (Mapper → DTO 그대로 반환)
      */
-    public TraineeTrainingDetailResponseDTO getTrainingDetail(TraineeTrainingDetailRequestDTO request) {
+    private TraineeTrainingDetailResponseDTO getUnpurchasedTrainingDetail(TraineeTrainingDetailRequestDTO request) {
         return traineeTrainingMapper.findTrainingDetail(request.getTrainingId());
     }
 
-    public List<TraineeTrainingListResponseDTO> getAllApprovedTrainings() {
-        return traineeTrainingMapper.findAllApprovedTrainings();
+    /**
+     * 전체 트레이닝 목록 조회
+     */
+    public List<TraineeTrainingListResponseDTO> getAllApprovedTrainings(Long userId) {
+        return traineeTrainingMapper.findAllApprovedTrainings(userId);
     }
-    public TraineeTrainingReviewResponseDTO getTrainingTitle (Long trainingId) {
+
+    /**
+     * 트레이닝 제목 조회
+     */
+    public TraineeTrainingReviewResponseDTO getTrainingTitle(Long trainingId) {
         return traineeTrainingMapper.findTrainingTitleByTrainingId(trainingId);
     }
 
+    /**
+     * 리뷰 작성
+     */
     @Transactional
     public void createReview(Long userId, Long trainingId, TraineeTrainingReviewCreateDTO dto) {
         traineeTrainingMapper.insertReview(userId, trainingId, dto.getRating(), dto.getContent());

--- a/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
+++ b/src/main/java/com/kbulkup/training/service/TraineeTrainingService.java
@@ -61,6 +61,8 @@ public class TraineeTrainingService {
                 training.getAverageRating(),
                 training.getTraineeCount(),
                 progress,
+                training.getTrainerNickname(),
+                training.getTrainerProfileUrl(),
                 groupedRoutines
         );
     }

--- a/src/main/resources/mappers/TraineeTrainingPaymentMapper.xml
+++ b/src/main/resources/mappers/TraineeTrainingPaymentMapper.xml
@@ -15,5 +15,23 @@
                 )
     </insert>
 
+    <!-- ✅ 방금 등록한 enrollment_id 조회 -->
+    <select id="findEnrollmentId" resultType="long">
+        SELECT enrollment_id
+        FROM enrollments
+        WHERE user_id = #{userId}
+          AND training_id = #{trainingId}
+        ORDER BY created_at DESC
+            LIMIT 1
+    </select>
+
+    <!-- ✅ routine_results 초기화 (루틴별 기본 결과 생성) -->
+    <insert id="insertRoutineResultsForEnrollment">
+        INSERT INTO routine_results (enrollment_id, routine_id, status, pass_fail_result)
+        SELECT #{enrollmentId}, r.routine_id, FALSE, NULL
+        FROM routines r
+        WHERE r.training_id = #{trainingId}
+    </insert>
+
 </mapper>
 

--- a/src/main/resources/mappers/training/TraineeTrainingMapper.xml
+++ b/src/main/resources/mappers/training/TraineeTrainingMapper.xml
@@ -57,19 +57,24 @@
     <select id="findAllApprovedTrainings"
             resultType="com.kbulkup.training.dto.response.TraineeTrainingListResponseDTO">
         SELECT t.training_id AS trainingId,
-               t.title AS title,
-               u.username AS trainerName,
-               t.average_rating AS averageRating,
-               t.trainee_count AS traineeCount,
-               t.price AS price,
-               t.thumbnail_url AS thumbnailUrl,
-               t.level AS level,
-               t.category AS category
+        t.title,
+        u.username AS trainerName,
+        t.average_rating AS averageRating,
+        t.trainee_count AS traineeCount,
+        t.price,
+        t.thumbnail_url AS thumbnailUrl,
+        t.level,
+        t.category,
+        CASE WHEN e.user_id IS NOT NULL THEN TRUE ELSE FALSE END AS purchased
         FROM trainings t
-                 JOIN users u ON t.trainer_id = u.user_id
+        JOIN users u ON t.trainer_id = u.user_id
+        LEFT JOIN enrollments e
+        ON e.training_id = t.training_id
+        AND e.user_id = #{userId}    <!-- 로그인 사용자 기준 -->
         WHERE t.approval_status = '승인'
         ORDER BY t.created_at DESC
     </select>
+
 
     <!-- 결제 전 트레이닝 상세 조회 (루틴 총점수 포함) -->
     <select id="findTrainingDetail" parameterType="long"
@@ -107,9 +112,17 @@
         WHERE training_id = #{trainingId}
     </select>
 
+    <select id="isTrainingPurchased" resultType="boolean">
+        SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+        FROM enrollments
+        WHERE training_id = #{trainingId}
+          AND user_id = #{userId}
+    </select>
+
     <insert id="insertReview">
         INSERT INTO reviews (user_id, training_id, rating, content)
         VALUES (#{userId}, #{trainingId}, #{rating}, #{content})
     </insert>
+
 
 </mapper>

--- a/src/main/resources/mappers/training/TraineeTrainingMapper.xml
+++ b/src/main/resources/mappers/training/TraineeTrainingMapper.xml
@@ -6,15 +6,22 @@
 
     <!-- 결제 후 트레이닝 기본 정보 -->
     <select id="findTrainingById" resultType="com.kbulkup.routine.dto.TraineeRoutineSummaryResponseDTO">
-        SELECT t.title, t.description, t.price, t.category, t.level,
-               t.total_score AS totalScore, -- 기존 total_score는 더 이상 사용 안함
-               t.average_rating AS averageRating,
-               t.trainee_count AS traineeCount,
-               e.progress
+        SELECT t.title,
+        t.description,
+        t.price,
+        t.category,
+        t.level,
+        t.total_score AS totalScore,
+        t.average_rating AS averageRating,
+        t.trainee_count AS traineeCount,
+        u.username AS trainerNickname,        <!-- ✅ 트레이너명 -->
+        u.user_profile_url AS trainerProfileUrl, <!-- ✅ 트레이너 프로필 -->
+        e.progress
         FROM trainings t
-                 JOIN enrollments e ON e.training_id = t.training_id
+        JOIN enrollments e ON e.training_id = t.training_id
+        JOIN users u ON t.trainer_id = u.user_id        <!-- ✅ 트레이너 정보 JOIN -->
         WHERE t.training_id = #{trainingId}
-          AND e.user_id = #{userId}
+        AND e.user_id = #{userId}
     </select>
 
     <!-- 루틴 목록 조회 (루틴 타입 포함) -->

--- a/src/main/resources/mappers/training/TraineeTrainingMapper.xml
+++ b/src/main/resources/mappers/training/TraineeTrainingMapper.xml
@@ -17,19 +17,22 @@
           AND e.user_id = #{userId}
     </select>
 
-    <!-- 루틴 목록 조회 -->
+    <!-- 루틴 목록 조회 (루틴 타입 포함) -->
     <select id="findRoutinesByTraining" resultType="com.kbulkup.routine.dto.RoutineSummaryResponseDTO">
-        SELECT r.routine_id AS routineId,
+        SELECT r.routine_id   AS routineId,
                r.title,
-               r.score AS rewardPoint,
-               rr.status AS completed,
+               r.routine_type AS routineType,
+               r.score        AS rewardPoint,
+               rr.status      AS completed,
                rr.submitted_at AS completedAt
         FROM routines r
-                 JOIN routine_results rr ON r.routine_id = rr.routine_id
-                 JOIN enrollments e ON rr.enrollment_id = e.enrollment_id
+            JOIN routine_results rr ON r.routine_id = rr.routine_id
+            JOIN enrollments e ON rr.enrollment_id = e.enrollment_id
         WHERE r.training_id = #{trainingId}
           AND e.user_id = #{userId}
+        ORDER BY r.order_number ASC
     </select>
+
 
     <select id="countCompletedRoutines" resultType="int">
         SELECT COUNT(*)

--- a/src/main/resources/mappers/training/TrainingSearchMapper.xml
+++ b/src/main/resources/mappers/training/TrainingSearchMapper.xml
@@ -8,22 +8,21 @@
             parameterType="String"
             resultType="com.kbulkup.training.dto.response.TrainingSearchListResponseDTO">
 
-        SELECT
-            t.training_id AS trainingId,
-            t.title,
-            u.username AS trainerName,
-            t.average_rating,
-            t.trainee_count,
-            t.price,
-            t.thumbnail_url,
-            t.level,
-            t.category
+        SELECT t.training_id AS trainingId,
+               t.title,
+               u.username AS trainerName,
+               t.average_rating AS averageRating,
+               t.trainee_count AS traineeCount,
+               t.price,
+               t.thumbnail_url AS thumbnailUrl,
+               t.level,
+               t.category
         FROM trainings t
                  JOIN users u ON t.trainer_id = u.user_id
         WHERE t.approval_status = '승인'
-          AND t.title LIKE CONCAT('%', #{keyword}, '%')
+          AND ( REPLACE(t.title, ' ', '') LIKE CONCAT('%', REPLACE(#{keyword}, ' ', ''), '%')
+            OR REPLACE(u.username, ' ', '') LIKE CONCAT('%', REPLACE(#{keyword}, ' ', ''), '%') )
         ORDER BY t.created_at DESC
-
     </select>
 
 </mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #112 

## ✨️ 작업 내용
- [x] 결제 후 트레이닝 상세 페이지_ 루틴 타입 별 루틴 표시
- [x] 검색 API_띄어쓰기 여부 상관 없이 검색 기능, 강사명 검색 로직 추가
- [x] 전체 트레이닝 목록 API_결제 된 트레이닝은 결제 후 트레이닝 상세 페이지로 연결 되도록 로직 추가
- [x] 결제 페이지와 API연동 후 결제 페이지 리로드 해서 루틴정보 갱신해서 불러오는 로직 추가

## 💙 코멘트 (선택)

## 📸 구현 결과 (선택)
