### PR TITLE
[Feature] #114 : 트레이니 프로필 조회 API 및 실패 시 예외 코드 추가

### DIFF
--- a/src/main/java/com/kbulkup/common/response/ResponseCode.java
+++ b/src/main/java/com/kbulkup/common/response/ResponseCode.java
@@ -32,6 +32,7 @@ public enum ResponseCode {
   NO_ROLE_ASSIGNED(BAD_REQUEST, "사용자에게 할당된 역할이 없습니다."),
   DUPLICATE_ROLE(BAD_REQUEST, "이미 해당 역할로 가입된 사용자입니다."),
   NOT_FOUND_TRAINER_PROFILE(BAD_REQUEST,"트레이너 프로필 정보를 찾을 수 없습니다."), // 메시지 중복 있어서 위에 하나 있음
+  NOT_FOUND_TRAINEE_PROFILE(BAD_REQUEST,"트레이니 프로필 정보를 찾을 수 없습니다."),
   USER_NOT_FOUND(BAD_REQUEST, "사용자를 찾을 수 없습니다."), // AUTH_USER_NOT_FOUND 와 의미 중복
   INVALID_ENUM(BAD_REQUEST, "유효하지 않은 ENUM 값입니다."),
   INVALID_SQL_QUERY(BAD_REQUEST, "올바르지 않은 SQL 쿼리문입니다."),

--- a/src/main/java/com/kbulkup/profile/controller/TraineeProfileController.java
+++ b/src/main/java/com/kbulkup/profile/controller/TraineeProfileController.java
@@ -1,0 +1,25 @@
+package com.kbulkup.profile.controller;
+
+import com.kbulkup.common.response.CustomResponse;
+import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.profile.dto.response.TraineeProfileDetailResponseDTO;
+import com.kbulkup.profile.service.TraineeProfileService;
+import com.kbulkup.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trainee/profiles")
+public class TraineeProfileController {
+
+    private final TraineeProfileService traineeProfileService;
+
+    @GetMapping("/me")
+    public CustomResponse<TraineeProfileDetailResponseDTO> getTrainerProfile(@AuthenticationPrincipal(expression = "user") User user) {
+        return CustomResponse.success(ResponseCode.SUCCESS, traineeProfileService.getTraineeProfile(user.getUserId()));
+    }
+}

--- a/src/main/java/com/kbulkup/profile/dto/response/TraineeProfileDetailResponseDTO.java
+++ b/src/main/java/com/kbulkup/profile/dto/response/TraineeProfileDetailResponseDTO.java
@@ -1,0 +1,22 @@
+package com.kbulkup.profile.dto.response;
+
+import com.kbulkup.user.domain.User;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TraineeProfileDetailResponseDTO {
+    private String username;
+    private int growthScore;
+
+    public static TraineeProfileDetailResponseDTO toDTO(User user) {
+        return TraineeProfileDetailResponseDTO.builder()
+                .username(user.getUsername())
+                .growthScore(user.getGrowthScore())
+                .build();
+    }
+}

--- a/src/main/java/com/kbulkup/profile/service/TraineeProfileService.java
+++ b/src/main/java/com/kbulkup/profile/service/TraineeProfileService.java
@@ -1,0 +1,10 @@
+package com.kbulkup.profile.service;
+
+
+import com.kbulkup.profile.dto.response.TraineeProfileDetailResponseDTO;
+
+public interface TraineeProfileService {
+
+    TraineeProfileDetailResponseDTO getTraineeProfile(Long trainerId);
+
+}

--- a/src/main/java/com/kbulkup/profile/service/TraineeProfileServiceImpl.java
+++ b/src/main/java/com/kbulkup/profile/service/TraineeProfileServiceImpl.java
@@ -1,0 +1,23 @@
+package com.kbulkup.profile.service;
+
+import com.kbulkup.common.exception.ProfileException;
+import com.kbulkup.common.response.ResponseCode;
+import com.kbulkup.profile.dto.response.TraineeProfileDetailResponseDTO;
+import com.kbulkup.user.domain.User;
+import com.kbulkup.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TraineeProfileServiceImpl implements TraineeProfileService {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public TraineeProfileDetailResponseDTO getTraineeProfile(Long traineeId) {
+        User user = userMapper.findById(traineeId).
+                orElseThrow(() -> new ProfileException(ResponseCode.NOT_FOUND_TRAINEE_PROFILE));
+        return TraineeProfileDetailResponseDTO.toDTO(user);
+    }
+}


### PR DESCRIPTION
## 📑 이슈 번호
- close #114 

## ✨️ 작업 내용
- [x] `ResponseCode`에 `NOT_FOUND_TRAINEE_PROFILE` 추가
- [x] `TraineeProfileServiceImpl`에서 사용자 조회 실패 시 `ProfileException` 발생하도록 수정
- [x] 트레이니 정보 조회 API

## 💙 코멘트 (선택)

## 📸 구현 결과 (선택)
<img width="298" height="191" alt="image" src="https://github.com/user-attachments/assets/be0461a8-f735-45bd-88de-e0788b7ceeeb" />