### PR TITLE
[Refactor] #189 : 루틴 수행 처리 로직 수정

### DIFF
--- a/src/main/resources/mappers/review/ReviewMapper.xml
+++ b/src/main/resources/mappers/review/ReviewMapper.xml
@@ -19,6 +19,7 @@
         SELECT EXISTS (
             SELECT 1
             FROM reviews
+
             WHERE user_id = #{userId}
               AND training_id = #{trainingId}
         )

--- a/src/main/resources/mappers/routine/RoutineResultMapper.xml
+++ b/src/main/resources/mappers/routine/RoutineResultMapper.xml
@@ -29,13 +29,13 @@
     <insert id="insertRoutineResult" parameterType="com.kbulkup.routine.domain.RoutineResult">
         INSERT INTO routine_results (
         enrollment_id, routine_id,
-        status,                             <!-- ★ status를 직접 넣되 -->
+        status,                             <!-- status를 직접 넣되 -->
         awared_score, pass_fail_result,
         answer_text, evidence_url, submitted_at
         )
         VALUES (
         #{enrollmentId}, #{routineId},
-        CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- ★ PASS 기준으로 강제 동기화 -->
+        CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- PASS 기준으로 강제 동기화 -->
         #{awaredScore}, #{passFailResult},
         #{answerText}, #{evidenceUrl}, #{submittedAt}
         )
@@ -43,7 +43,7 @@
 
     <update id="updateRoutineResult" parameterType="com.kbulkup.routine.domain.RoutineResult">
         UPDATE routine_results
-        SET status = CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- ★ 동기화 -->
+        SET status = CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- 동기화 -->
         awared_score = #{awaredScore},
         pass_fail_result = #{passFailResult},
         answer_text = #{answerText},

--- a/src/main/resources/mappers/routine/RoutineResultMapper.xml
+++ b/src/main/resources/mappers/routine/RoutineResultMapper.xml
@@ -27,15 +27,23 @@
     </select>
 
     <insert id="insertRoutineResult" parameterType="com.kbulkup.routine.domain.RoutineResult">
-        INSERT INTO routine_results (enrollment_id, routine_id, status, awared_score, pass_fail_result,
-        answer_text, evidence_url, submitted_at)
-        VALUES (#{enrollmentId}, #{routineId}, #{status}, #{awaredScore}, #{passFailResult},
-        #{answerText}, #{evidenceUrl}, #{submittedAt})
+        INSERT INTO routine_results (
+        enrollment_id, routine_id,
+        status,                             <!-- ★ status를 직접 넣되 -->
+        awared_score, pass_fail_result,
+        answer_text, evidence_url, submitted_at
+        )
+        VALUES (
+        #{enrollmentId}, #{routineId},
+        CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- ★ PASS 기준으로 강제 동기화 -->
+        #{awaredScore}, #{passFailResult},
+        #{answerText}, #{evidenceUrl}, #{submittedAt}
+        )
     </insert>
 
     <update id="updateRoutineResult" parameterType="com.kbulkup.routine.domain.RoutineResult">
         UPDATE routine_results
-        SET status = #{status},
+        SET status = CASE WHEN #{passFailResult} = 'PASS' THEN TRUE ELSE FALSE END,  <!-- ★ 동기화 -->
         awared_score = #{awaredScore},
         pass_fail_result = #{passFailResult},
         answer_text = #{answerText},

--- a/src/main/resources/mappers/training/TraineeTrainingMapper.xml
+++ b/src/main/resources/mappers/training/TraineeTrainingMapper.xml
@@ -36,7 +36,7 @@
                r.routine_type AS routineType,
                r.quiz_type    AS quizType,
                r.score        AS rewardPoint,
-               lr.status      AS completed,
+               CASE WHEN lr.pass_fail_result = 'PASS' THEN TRUE ELSE FALSE END AS completed,
                lr.submitted_at AS completedAt
         FROM routines r
                  /* 수강행 먼저 확정 (userId, trainingId) */
@@ -65,17 +65,16 @@
         FROM (
                  SELECT rr.routine_id,
                         ROW_NUMBER() OVER (
-             PARTITION BY rr.routine_id, rr.enrollment_id
-             ORDER BY rr.submitted_at DESC, rr.routine_result_id DESC
-           ) AS rn,
-                         rr.status
+           PARTITION BY rr.routine_id, rr.enrollment_id
+           ORDER BY rr.submitted_at DESC, rr.routine_result_id DESC
+         ) AS rn,
+                         rr.pass_fail_result
                  FROM routine_results rr
-                          JOIN enrollments e
-                               ON e.enrollment_id = rr.enrollment_id
-                                   AND e.training_id   = #{trainingId}
-                                   AND e.user_id       = #{userId}
+                          JOIN enrollments e ON e.enrollment_id = rr.enrollment_id
+                     AND e.training_id   = #{trainingId}
+                     AND e.user_id       = #{userId}
              ) x
-        WHERE x.rn = 1 AND x.status = TRUE
+        WHERE x.rn = 1 AND x.pass_fail_result = 'PASS'
     </select>
 
     <select id="countTotalRoutines" resultType="int">


### PR DESCRIPTION
## 📑 이슈 번호
- close #189 

## ✨️ 작업 내용
- [ ] 루틴 완료 판정의 단일 기준(SSOT) 을 pass_fail_result='PASS'로 통일
- [ ] 체크표시/진행률/리스트가 모두 같은 기준으로 동작하도록 서버 쿼리와 DML을 정리

## 💙 코멘트 (선택)

## 📸 구현 결과 (선택)
